### PR TITLE
fix: atlas freshness checks and memory format migration

### DIFF
--- a/agents/codebase-navigator.md
+++ b/agents/codebase-navigator.md
@@ -19,7 +19,7 @@ Before doing any discovery, check for existing context on this project:
 1. Run `git rev-parse --show-toplevel 2>/dev/null || pwd` to get the project root
 2. Derive the project name from the root directory name
 3. Read `~/.claude/agent-memory/codebase-navigator/MEMORY.md` to see if an atlas exists
-4. If atlas is recent (< 2 weeks old), read `~/.claude/agent-memory/codebase-navigator/<project-name>.md` and consider skipping full re-orientation
+4. If an atlas exists, apply the Memory Protocol (below) to decide: use as-is, run the Incremental Update Procedure, or run full Phase 1-4
 5. Check for an existing knowledge graph:
    If `graphify-out/graph.json` exists, run `graphify query "What is the architecture, conventions, layer map, and key patterns of this project?"` and use the results alongside the atlas to avoid re-deriving known facts.
    If neither the atlas nor a graph exists, run full Phase 1–4.
@@ -115,18 +115,20 @@ The best-implemented feature is X in path/to/X/. When implementing anything new,
 Key reasons: <why this is the best example>
 
 ## Known Technical Debt
-- <issue> in <location>: <severity and impact>
+- [YYYY-MM-DD] <issue> in <location>: <severity and impact>
 
 ## Gotchas
-- <Non-obvious things that will cause confusion>
+- [YYYY-MM-DD] <Non-obvious things that will cause confusion>
 ```
+
+Each `## Known Technical Debt` and `## Gotchas` entry is dated with the date it was observed/verified — independent of the atlas's top-level `Last updated`. New entries get today's date; re-verified entries get their date bumped; resolved entries are removed.
 
 ## Behavioral Rules
 
 - **Do not skim**: Read actual code, not just filenames. A file called `service.go` might be a handler. Read it.
 - **Verify conventions by triangulation**: Don't infer a convention from one example. Look at 3-5 examples before asserting a pattern.
 - **Flag inconsistencies explicitly**: If the codebase has mixed patterns (some old-style, some new), document both and note which is the preferred modern approach.
-- **Update, don't replace**: When re-running on a known project, diff what changed rather than overwriting everything. Note what shifted.
+- **Update, don't replace**: When re-running on a known project, follow the Incremental Update Procedure (Memory Protocol) — diff each dated `## Known Technical Debt`/`## Gotchas` entry against `git log --since=<entry-date>` for its path, and only re-derive sections the freshness check shows have actually changed.
 - **Be honest about uncertainty**: If you can't determine the pattern, say so and list the files that would need deeper reading to clarify.
 - **Scope the work**: If the codebase is very large, build the atlas incrementally — cover the core architecture first, then expand to subsystems.
 
@@ -140,10 +142,27 @@ When asked questions about codebase structure, conventions, or "where does X liv
 ## Memory Protocol
 
 At the start of every session:
-1. Check `MEMORY.md` to see if you have a recent atlas for this project
-2. If atlas is less than 2 weeks old and the project hasn't changed significantly, use it directly
-3. If atlas is stale or missing, run the full orientation process
-4. Always update `MEMORY.md` with the current date after working on a project
+1. Check `MEMORY.md` to see if an atlas exists for this project
+2. If it exists, check its format against the Atlas File Format above: does it have `## Known Technical Debt` and `## Gotchas` sections with `[YYYY-MM-DD]`-dated entries?
+   - **Format matches** → continue to step 3
+   - **Format differs** (old/renamed sections such as `## Key Invariants / Gotchas` or `## Technical Debt / Known Issues`, or entries with no date) → run a **Migration Pass**: rename sections to the current template's headings, add `[YYYY-MM-DD]` (today) to any undated entries, then continue to step 3 using the migrated entries
+3. Run `git log --since="<atlas Last-updated date>" --oneline | head -20`:
+   - **No commits** → atlas is current, use directly
+   - **Commits exist, `Last updated` ≤ 30 days old** → run the Incremental Update Procedure below (don't redo Phase 1-4 from scratch)
+   - **`Last updated` > 30 days old** → run full Phase 1-4
+4. No atlas, or no parseable `Last updated` date → run full Phase 1-4
+5. Always update `MEMORY.md` and the atlas's `Last updated` date after working on a project
+
+### Incremental Update Procedure
+
+1. For each dated entry in `## Known Technical Debt` / `## Gotchas`, run `git log --since="<entry-date>" --oneline --name-only -- <path-from-entry>` (dedupe paths first)
+2. For entries whose path has commits since their date:
+   - Resolved → remove the entry
+   - Still an issue but details changed → update description, bump date to today
+   - Still accurate → bump date to today (re-verified), keep description
+3. Entries with no commits since their date: leave untouched
+4. If any of those commits touched `## Layer Map` or `## Canonical Example` paths, spot-check those sections too
+5. Update the atlas's top-level `Last updated:` to today and write the file
 
 ## graphify Protocol
 

--- a/agents/feature-path-tracer.md
+++ b/agents/feature-path-tracer.md
@@ -21,7 +21,7 @@ Before doing any discovery, check if `codebase-navigator` has already mapped thi
 3. Read `~/.claude/agent-memory/codebase-navigator/MEMORY.md` to see if an atlas exists
 4. If yes, read `~/.claude/agent-memory/codebase-navigator/<project-name>.md`
 5. Use the atlas to understand the layer structure — it tells you which directories contain handlers, services, repositories, etc., accelerating the trace significantly
-6. Check `~/.claude/agent-memory/feature-path-tracer/` for prior traces of this path — if one exists, verify it is still current rather than re-tracing from scratch.
+6. Check `~/.claude/agent-memory/feature-path-tracer/<project-name>.md` for prior traces of this path — if one exists, verify it is still current rather than re-tracing from scratch.
    If `graphify-out/graph.json` exists, `graphify path "<entry point>" "<outcome>"` may also help confirm the route. If neither exists, continue with the atlas.
 
 ### Step 1: Identify the Entry Point
@@ -111,14 +111,13 @@ Before finalizing your trace summary:
 - Ensure every branch decision is explicitly documented
 - Check that the trace outcome accurately reflects the terminal state of the traced path
 
-**Update your agent memory** as you discover architectural patterns, layer conventions, naming standards, and execution flow structures in this codebase. This builds institutional knowledge across tracing sessions.
+**Record the completed trace** in `~/.claude/agent-memory/feature-path-tracer/<project-name>.md` — this builds a library of traced paths so the same path is never re-traced from scratch.
 
 Examples of what to record:
-- Layer naming conventions (e.g., Controllers call Services which call Repositories)
-- Common middleware chains and their order
-- Recurring conditional patterns (e.g., auth checks always happen in middleware, not services)
-- Key abstractions or base classes that delegate to concrete implementations
-- File structure patterns that help locate handlers, services, and models quickly
+- The traced path itself: entry point, full call chain with file:line citations, branch decisions made, and the outcome
+- Trace-specific findings not yet reflected in codebase-navigator's atlas (e.g., a middleware ordering or data-transformation quirk discovered mid-trace)
+
+Architecture, layer conventions, and naming standards belong in codebase-navigator's atlas (Phase 0 step 4) — if you discover one that's missing or wrong there, mention it in your summary so the user can route a `codebase-navigator` refresh, rather than duplicating it in this agent's memory.
 
 ## Chaining
 
@@ -131,33 +130,31 @@ After completing a trace:
 
 # Persistent Agent Memory
 
-You have a persistent Persistent Agent Memory directory at `~/.claude/agent-memory/feature-path-tracer/`. Its contents persist across conversations.
+You have a persistent memory directory at `~/.claude/agent-memory/feature-path-tracer/`. Its contents persist across conversations.
 
-As you work, consult your memory files to build on previous experience. When you encounter a mistake that seems like it could be common, check your Persistent Agent Memory for relevant notes — and if nothing is written yet, record what you learned.
+As you work, consult your memory files to build on previous experience — check whether the path you're about to trace was already traced before re-deriving it from scratch.
 
 Guidelines:
-- `MEMORY.md` is always loaded into your system prompt — lines after 200 will be truncated, so keep it concise
-- Create separate topic files (e.g., `debugging.md`, `patterns.md`) for detailed notes and link to them from MEMORY.md
+- `MEMORY.md` is always loaded into your system prompt — lines after 200 will be truncated, so keep it as an index, not a content dump
+- Store each project's traced-path history in a separate file named after the project root directory (e.g., `tagmi.in.md`), and link to it from `MEMORY.md`
 - Update or remove memories that turn out to be wrong or outdated
-- Organize memory semantically by topic, not chronologically
+- Organize memory semantically by project, not chronologically
 - Use the Write and Edit tools to update your memory files
 
-What to save:
-- Stable patterns and conventions confirmed across multiple interactions
-- Key architectural decisions, important file paths, and project structure
-- User preferences for workflow, tools, and communication style
-- Solutions to recurring problems and debugging insights
+What to save (per project file):
+- Previously traced paths: entry point, full call chain with file:line citations, branch decisions, and outcome — so a repeat request for the same path skips straight to the answer
+- Trace-specific findings not yet reflected in codebase-navigator's atlas
+- User preferences for workflow, tools, and communication style (general, not project-specific — these can live in MEMORY.md directly)
 
 What NOT to save:
+- Architecture, layer maps, naming conventions, or file paths already covered by `~/.claude/agent-memory/codebase-navigator/<project-name>.md` (Phase 0 step 4) — flag gaps there instead of duplicating
 - Session-specific context (current task details, in-progress work, temporary state)
 - Information that might be incomplete — verify against project docs before writing
-- Anything that duplicates or contradicts existing CLAUDE.md instructions
 - Speculative or unverified conclusions from reading a single file
 
 Explicit user requests:
 - When the user asks you to remember something across sessions (e.g., "always use bun", "never auto-commit"), save it — no need to wait for multiple interactions
 - When the user asks to forget or stop remembering something, find and remove the relevant entries from your memory files
-- Since this memory is user-scope, keep learnings general since they apply across all projects
 
 ## Searching past context
 
@@ -174,7 +171,7 @@ Use narrow search terms (error messages, file paths, function names) rather than
 
 ## MEMORY.md
 
-Your MEMORY.md is currently empty. When you notice a pattern worth preserving across sessions, save it here. Anything in MEMORY.md will be included in your system prompt next time.
+`MEMORY.md` is the index of traced projects — one line per project linking to `<project-name>.md`. When you complete a trace in a new project, add or update its entry here.
 
 ## Available Skills
 

--- a/docs/development/agent-architecture-reference.md
+++ b/docs/development/agent-architecture-reference.md
@@ -17,6 +17,7 @@ Every agent that operates on a codebase must begin with **Phase 0: Orient** befo
 2. Derive the project name from the root directory name
 3. Read `~/.claude/agent-memory/codebase-navigator/MEMORY.md` to see if an atlas exists
 4. If yes, read `~/.claude/agent-memory/codebase-navigator/<project-name>.md` — use stack, layer map, canonical example, and conventions; skip re-deriving what's already there
+4a. **If your task consults `## Known Technical Debt` or `## Gotchas`**: extract the date(s) and file path(s) from the entries you're relying on, then run `git log --since="<entry-date>" --oneline -- <path-from-entry> 2>/dev/null`. If this returns commits, treat that specific entry as unverified — read the current file instead of restating the claim. **If an entry has no `[YYYY-MM-DD]` date at all (pre-migration format), treat it as unverified by default regardless of commit history** — read the current file. If the atlas's top-level `Last updated` date is >30 days old, also note that a `codebase-navigator` refresh may be worthwhile.
 5. Check for an existing knowledge graph:
    Check whether `graphify-out/graph.json` exists in the project root.
    If yes: run `graphify query "<domain-specific question for this agent>"` and use the results to surface conventions, ADRs, and known issues relevant to the agent's task.
@@ -194,6 +195,9 @@ Agents with `memory: user` in frontmatter have a persistent memory directory at 
 - Save stable, cross-session facts — not session-specific context
 - Always update when the user explicitly asks you to remember or forget something
 - graphify is a complement to memory, not a replacement — memory is agent-private, the knowledge graph (when one exists) is shared and per-project
+- **Dated atlas entries are advisory, not absolute**: `## Known Technical Debt` and `## Gotchas` entries carry a `[YYYY-MM-DD]` observation date. Before repeating one of these claims in your own output, do the Phase 0 step 4a freshness check — don't propagate a claim that may already be resolved.
+- **Don't duplicate the atlas**: if Phase 0 already reads `~/.claude/agent-memory/codebase-navigator/<project>.md`, your memory should hold only what that atlas doesn't — your agent's own domain-specific findings (e.g., prior trace results, prior audit findings, prior groomed tickets), not architecture, layer maps, conventions, or file paths the atlas already covers.
+- **Self-heal format drift**: if your memory files (atlas, `MEMORY.md`, or topic files) use section names or structures from a previous version of this convention, migrate them to the current structure as part of your normal write-back for that session — don't perpetuate an outdated format indefinitely. codebase-navigator's Memory Protocol Migration Pass is the concrete implementation of this for atlases.
 
 ---
 
@@ -207,5 +211,6 @@ Before submitting a new agent file, verify:
 - [ ] context7 usage documented where the agent writes code or reviews library usage
 - [ ] `## Chaining` section present at end of body
 - [ ] `/graphify --update` write-back included if the agent produces knowledge artifacts
+- [ ] If Phase 0 reads `## Known Technical Debt`/`## Gotchas` from the atlas, step 4a's freshness check is applied before repeating any claim
 - [ ] All tools in `tools:` frontmatter are actually used in the body
 - [ ] Installed via `./install.sh` after changes

--- a/skills/devxp/SKILL.md
+++ b/skills/devxp/SKILL.md
@@ -50,7 +50,7 @@ ls ~/.claude/agent-memory/codebase-navigator/MEMORY.md 2>/dev/null && echo "atla
 ```
 
 Then judge **staleness**, not just existence:
-- Derive the project name from the repo root directory name; check `~/.claude/agent-memory/codebase-navigator/<project-name>.md` for an atlas and note its last-updated date
+- Derive the project name from the repo root directory name; check `~/.claude/agent-memory/codebase-navigator/<project-name>.md` for an atlas. Run `git log --since="<atlas Last-updated date>" --oneline | head -5` against the project root — if this returns commits and the atlas is >30 days old, route the atlas row as "stale" → `codebase-navigator` (rebuild); otherwise "found, current" → skip.
 - Compare `CLAUDE.md` / `docs/README.md` last-commit dates against recent code activity (`git log -5 --format="%ai" -- <a likely-active source dir>`) — if substantial code has changed since the doc's last touch, treat it as **stale**, not current
 - A missing `[NOT FOUND]` marker that's now answerable, or a canonical example that's moved, are also staleness signals — but you don't need to do that deep a check here; `gen-indexer`/`update-indexer` and `gen-docs`/`update-docs` do their own thorough drift detection. Your job is just to route correctly, not to pre-diagnose.
 

--- a/templates/agent-template.md
+++ b/templates/agent-template.md
@@ -82,6 +82,7 @@ Before doing any discovery work:
 2. Derive the project name from the root directory name
 3. Read `~/.claude/agent-memory/codebase-navigator/MEMORY.md` to see if an atlas exists
 4. If yes, read `~/.claude/agent-memory/codebase-navigator/<project-name>.md` — it gives you stack, entry points, conventions, and the canonical example instantly
+4a. **If your task consults `## Known Technical Debt` or `## Gotchas`**: extract the date(s) and file path(s) from the entries you're relying on, then run `git log --since="<entry-date>" --oneline -- <path-from-entry> 2>/dev/null`. If this returns commits, treat that specific entry as unverified — read the current file instead of restating the claim. **If an entry has no `[YYYY-MM-DD]` date at all (pre-migration format), treat it as unverified by default regardless of commit history** — read the current file. If the atlas's top-level `Last updated` date is >30 days old, also note that a `codebase-navigator` refresh may be worthwhile.
 5. Skip any discovery steps that the atlas already covers
 6. Check for an existing knowledge graph: if `graphify-out/graph.json` exists in the project root, run `graphify query "<describe what this agent needs>"` to supplement the atlas with code/doc relationships. If no graph exists, continue — the atlas is sufficient; building one is the user's call (`/graphify`), not the agent's.
 
@@ -125,6 +126,27 @@ Structure your output as follows:
 
 ### [Section 3 Name]
 [What goes here]
+
+## Persistent Agent Memory
+
+<!-- Only include this section if `memory: user` is set in frontmatter. Delete this section otherwise. -->
+
+You have a persistent memory directory at `~/.claude/agent-memory/<name>/`. Its contents persist across conversations.
+
+Guidelines:
+- `MEMORY.md` is always loaded into your system prompt — keep it under 200 lines; it's an index, not a content dump
+- Store per-project detail in `<project-name>.md`, named after the project root directory, and link to it from `MEMORY.md`
+- **Don't duplicate codebase-navigator's atlas** (`~/.claude/agent-memory/codebase-navigator/<project-name>.md`, read in Phase 0) — record only what's unique to this agent's domain, not architecture/conventions/file paths the atlas already covers
+- Organize memory semantically by project, not chronologically
+- If you notice your own memory files use a structure from an older version of this section, migrate them to the current structure as part of normal write-back
+- Update or remove memories that turn out to be wrong or outdated
+
+What to save:
+- [Domain-specific findings that took investigation to discover and would be expensive to re-derive — e.g., prior trace results, prior findings]
+
+What NOT to save:
+- Session-specific context (current task details, in-progress work)
+- Anything `~/.claude/agent-memory/codebase-navigator/<project-name>.md` already covers
 
 ---
 


### PR DESCRIPTION
## Summary
- **Gap 1**: `/devxp` and Phase 0 step 4a now check atlas staleness against git history before trusting dated Gotchas/Technical Debt entries, so resolved claims don't get propagated indefinitely.
- **Gap 2**: feature-path-tracer's memory now follows the index+topic-file convention (per-project trace records) instead of duplicating codebase-navigator's atlas. codebase-navigator's Memory Protocol gains a Migration Pass that reformats old-format atlases on the next run. The canonical Memory Convention and agent template now document "don't duplicate the atlas" and "self-heal format drift" as standard guardrails for all memory-enabled agents.

This is the foundation epic #12 (Stories 1, 2a, 2b, 3, 4) builds on — those stories roll the new "Persistent Agent Memory" convention out to the remaining 25 agents.

## Test plan
- [x] Re-read all edited agent/doc files; step numbering consistent (Memory Protocol 1-5, Phase 0's 4/4a/5/6)
- [x] New `feature-path-tracer/tagmi.in.md` preserves all facts from old MEMORY.md not covered by codebase-navigator's atlas
- [x] `feature-path-tracer/MEMORY.md` reduced from 31 lines to 3, matching grooming-agent's index shape
- [x] `devexp-toolkit.md` atlas: Gotcha 10 (false "READMEs are stale" claim) removed, remaining Gotchas renumbered 1-11, `Last updated: 2026-06-11`
- [x] Markdown-only change set — no code/tests to run

🤖 Generated with [Claude Code](https://claude.com/claude-code)