### PR TITLE
refactor: normalize Category B agents to canonical Persistent Agent Memory section

### DIFF
--- a/agents/backend-senior-dev.md
+++ b/agents/backend-senior-dev.md
@@ -152,7 +152,7 @@ Examples of what to record:
 - Previously identified technical debt items and their severity
 - Performance bottlenecks already discovered and their resolutions
 
-# Persistent Agent Memory
+## Persistent Agent Memory
 
 You have a persistent Persistent Agent Memory directory at `~/.claude/agent-memory/backend-senior-dev/`. Its contents persist across conversations.
 
@@ -161,8 +161,10 @@ As you work, consult your memory files to build on previous experience. When you
 Guidelines:
 - `MEMORY.md` is always loaded into your system prompt — lines after 200 will be truncated, so keep it concise
 - Create separate topic files (e.g., `debugging.md`, `patterns.md`) for detailed notes and link to them from MEMORY.md
+- **Don't duplicate codebase-navigator's atlas** (`~/.claude/agent-memory/codebase-navigator/<project-name>.md`) — record only what's unique to this agent's domain, not architecture/conventions/file paths the atlas already covers
 - Update or remove memories that turn out to be wrong or outdated
 - Organize memory semantically by topic, not chronologically
+- If you notice your own memory files use a structure from an older version of this section, migrate them to the current structure as part of normal write-back
 - Use the Write and Edit tools to update your memory files
 
 What to save:

--- a/agents/dep-audit.md
+++ b/agents/dep-audit.md
@@ -40,13 +40,23 @@ You are a **Dependency Auditor** — a specialist in supply-chain security and d
 
 Two separate concerns, treated separately: **security** (known CVEs in current versions) and **staleness** (outdated packages that may miss security patches or introduce compatibility risks). Both matter, but they're different categories with different urgency.
 
-## Memory Protocol
+## Persistent Agent Memory
+
+You have a persistent memory directory at `~/.claude/agent-memory/dep-audit/`. Its contents persist across conversations.
 
 On startup, read `~/.claude/agent-memory/dep-audit/MEMORY.md` if it exists. It may contain:
 - Known-acceptable vulnerabilities the user has previously reviewed and accepted
 - Packages the user has marked as "will not upgrade" with reasons
 
 Use this context to annotate findings — don't re-flag accepted items as surprises, but always include them in the report as "previously reviewed."
+
+Guidelines:
+- **Don't duplicate codebase-navigator's atlas** (`~/.claude/agent-memory/codebase-navigator/<project-name>.md`) — record only what's unique to this agent's domain, not architecture/conventions/file paths the atlas already covers
+- If you notice your own memory files use a structure from an older version of this section, migrate them to the current structure as part of normal write-back
+
+What to save:
+- Known-acceptable vulnerabilities the user has reviewed and accepted, with reasoning
+- Packages marked "will not upgrade" with reasons, so future audits don't re-flag them
 
 ## Workflow
 

--- a/agents/dev-agent.md
+++ b/agents/dev-agent.md
@@ -161,15 +161,17 @@ After completing tasks, record in per-project memory files:
 - Gotchas that took time to figure out
 - Technical debt items observed but not addressed (with location and severity)
 
-# Persistent Agent Memory
+## Persistent Agent Memory
 
 You have a persistent memory directory at `~/.claude/agent-memory/dev-agent/`. Its contents persist across conversations.
 
 Guidelines:
 - `MEMORY.md` is always loaded into your system prompt — keep it under 150 lines; use it as an index pointing to per-project files
 - Create separate per-project files (e.g., `time-based-rpg.md`) for detailed notes
+- **Don't duplicate codebase-navigator's atlas** (`~/.claude/agent-memory/codebase-navigator/<project-name>.md`) — record only what's unique to this agent's domain, not architecture/conventions/file paths the atlas already covers
 - Update memories when you discover something was wrong or outdated
 - Organize memory by project, then by category (bugs, patterns, debt, gotchas)
+- If you notice your own memory files use a structure from an older version of this section, migrate them to the current structure as part of normal write-back
 
 What to save:
 - Root causes of bugs fixed (with file locations) — prevents re-discovering the same issues
@@ -181,7 +183,7 @@ What to save:
 What NOT to save:
 - Session-specific task details or in-progress work
 - Information that might be incomplete — verify before writing
-- Anything that duplicates the codebase-navigator atlas
+- Anything the atlas already covers (see Guidelines above)
 
 ## Searching past context
 

--- a/agents/frontend-senior-dev.md
+++ b/agents/frontend-senior-dev.md
@@ -121,7 +121,7 @@ Examples of what to record:
 - State management and data-fetching strategies the team uses
 - Performance or accessibility baseline expectations for the project
 
-# Persistent Agent Memory
+## Persistent Agent Memory
 
 You have a persistent Persistent Agent Memory directory at `~/.claude/agent-memory/frontend-senior-dev/`. Its contents persist across conversations.
 
@@ -130,8 +130,10 @@ As you work, consult your memory files to build on previous experience. When you
 Guidelines:
 - `MEMORY.md` is always loaded into your system prompt — lines after 200 will be truncated, so keep it concise
 - Create separate topic files (e.g., `debugging.md`, `patterns.md`) for detailed notes and link to them from MEMORY.md
+- **Don't duplicate codebase-navigator's atlas** (`~/.claude/agent-memory/codebase-navigator/<project-name>.md`) — record only what's unique to this agent's domain, not architecture/conventions/file paths the atlas already covers
 - Update or remove memories that turn out to be wrong or outdated
 - Organize memory semantically by topic, not chronologically
+- If you notice your own memory files use a structure from an older version of this section, migrate them to the current structure as part of normal write-back
 - Use the Write and Edit tools to update your memory files
 
 What to save:

--- a/agents/grooming-agent.md
+++ b/agents/grooming-agent.md
@@ -274,11 +274,17 @@ If there's no graph, or graphify is unavailable, skip the rebuild — the ticket
 
 ---
 
-### Phase 9: Memory
+## Persistent Agent Memory
 
-After each groomed ticket, update agent memory at `~/.claude/agent-memory/grooming-agent/`:
+You have a persistent memory directory at `~/.claude/agent-memory/grooming-agent/`. Its contents persist across conversations.
 
-Record in `<PROJECT-NAME>.md`:
+Guidelines:
+- **Don't duplicate codebase-navigator's atlas** (`~/.claude/agent-memory/codebase-navigator/<project-name>.md`) — record only what's unique to this agent's domain, not architecture/conventions/file paths the atlas already covers
+- If you notice your own memory files use a structure from an older version of this section, migrate them to the current structure as part of normal write-back
+
+After each groomed ticket, update agent memory.
+
+What to save (in `<PROJECT-NAME>.md`):
 - Ticket ID + title
 - Verdict (READY / CORRECTED / BLOCKED)
 - Summary of corrections made (if any)
@@ -289,7 +295,7 @@ Update `MEMORY.md` index with the ticket entry.
 
 ---
 
-### Phase 10: Report
+### Phase 9: Report
 
 ```
 Groomed: <TICKET-ID> — <Title>

--- a/agents/migration.md
+++ b/agents/migration.md
@@ -211,9 +211,15 @@ Known Warnings:
 
 Write a `MIGRATION_NOTES.md` file at the project root with anything that requires follow-up manual work.
 
-## Memory
+## Persistent Agent Memory
 
-After completing a migration, record:
+You have a persistent memory directory at `~/.claude/agent-memory/migration/`. Its contents persist across conversations.
+
+Guidelines:
+- **Don't duplicate codebase-navigator's atlas** (`~/.claude/agent-memory/codebase-navigator/<project-name>.md`) — record only what's unique to this agent's domain, not architecture/conventions/file paths the atlas already covers
+- If you notice your own memory files use a structure from an older version of this section, migrate them to the current structure as part of normal write-back
+
+What to save:
 - What was migrated and when
 - Any non-obvious gotchas discovered
 - Patterns that made this migration harder or easier (for future migrations)

--- a/agents/runbook.md
+++ b/agents/runbook.md
@@ -257,16 +257,22 @@ If a specific command cannot be found in the project's configuration files, writ
 
 Never write a command based on assumption or convention. If the project uses Docker Compose but the restart command isn't in the Makefile or compose file, write the placeholder.
 
-### Phase 5: Update Memory
+## Persistent Agent Memory
 
-After writing the runbook, save context for future sessions:
-- Record the output directory used
-- Note any discovered service names and their canonical identifiers
-- Note the deployment mechanism (docker-compose / k8s / raw systemd / etc.)
+You have a persistent memory directory at `~/.claude/agent-memory/runbook/`. Its contents persist across conversations.
+
+Guidelines:
+- **Don't duplicate codebase-navigator's atlas** (`~/.claude/agent-memory/codebase-navigator/<project-name>.md`) — record only what's unique to this agent's domain, not architecture/conventions/file paths the atlas already covers
+- If you notice your own memory files use a structure from an older version of this section, migrate them to the current structure as part of normal write-back
+
+What to save:
+- The output directory used for runbooks in this project
+- Discovered service names and their canonical identifiers
+- The deployment mechanism (docker-compose / k8s / raw systemd / etc.)
 
 This saves discovery time when the next runbook is requested for the same project.
 
-### Phase 6: Report
+### Phase 5: Report
 
 ```
 ## Runbook Written

--- a/agents/test-gen.md
+++ b/agents/test-gen.md
@@ -152,9 +152,15 @@ After generating tests:
 - **Coverage audit completed** → suggest invoking `backend-senior-dev` or `frontend-senior-dev` to review the highest-risk untested modules
 - **Stubs only written** → suggest invoking `dev-agent` to implement the actual logic in the scaffolded test stubs
 
-## Memory
+## Persistent Agent Memory
 
-After generating tests for a project, record in memory:
+You have a persistent memory directory at `~/.claude/agent-memory/test-gen/`. Its contents persist across conversations.
+
+Guidelines:
+- **Don't duplicate codebase-navigator's atlas** (`~/.claude/agent-memory/codebase-navigator/<project-name>.md`) — record only what's unique to this agent's domain, not architecture/conventions/file paths the atlas already covers
+- If you notice your own memory files use a structure from an older version of this section, migrate them to the current structure as part of normal write-back
+
+What to save:
 - Which modules now have test coverage
 - Which gaps remain and why (too complex to mock, needs integration test, etc.)
 - Any project-specific testing gotchas discovered


### PR DESCRIPTION
## Summary
- Renames the existing memory section in 8 agents (`backend-senior-dev`, `frontend-senior-dev`, `dev-agent`, `dep-audit`, `runbook`, `migration`, `test-gen`, `grooming-agent`) to the canonical `## Persistent Agent Memory` heading.
- Inserts the two standard guardrail bullets in each — "don't duplicate codebase-navigator's atlas" and "self-heal memory format drift" — sourced from `templates/agent-template.md` (lines 139, 141) and `docs/development/agent-architecture-reference.md` (lines 199-200).
- `dev-agent.md` and `runbook.md`'s separate `## Memory Protocol` (Phase-0 consult) sections are left untouched — only the write-back section was renamed.
- `runbook.md` and `grooming-agent.md` had their memory section embedded as a numbered workflow phase (`### Phase 5: Update Memory`, `### Phase 9: Memory`); both are now standalone `## Persistent Agent Memory` sections, with the following phase (`Report`) renumbered down by one to close the gap.
- `dev-agent.md`'s pre-existing "Anything that duplicates the codebase-navigator atlas" bullet was trimmed to a cross-reference to avoid duplicating the new guardrail.

Closes #13 (Story 1 of epic #12 — rolling out the Persistent Agent Memory convention).

## Test plan
- [x] `grep -c "^## Persistent Agent Memory"` → `1` for all 8 files
- [x] `grep -c "^# Persistent Agent Memory$"` → `0` for all 8 files (no h1 remains)
- [x] `Memory Protocol` preserved (count `1`) in `dev-agent.md` and `runbook.md`
- [x] Both guardrail concepts present in all 8 files
- [x] `./install.sh --dry-run` — no errors
- [x] Markdown-only change set — no code/tests to run

🤖 Generated with [Claude Code](https://claude.com/claude-code)