### PR TITLE
refactor: add Persistent Agent Memory section to 9 analysis agents

### DIFF
--- a/agents/arch-review.md
+++ b/agents/arch-review.md
@@ -99,9 +99,17 @@ Produce a structured report:
 3. ...
 ```
 
-## Ingestion
+## Persistent Agent Memory
 
-After producing the Phase 5 report, write it to `~/.claude/agent-memory/arch-review/<date-slug>.md` (e.g. `2026-03.md`) to enable longitudinal architectural health comparison across review runs.
+You have a persistent memory directory at `~/.claude/agent-memory/arch-review/`. Its contents persist across conversations.
+
+Guidelines:
+- **Don't duplicate codebase-navigator's atlas** (`~/.claude/agent-memory/codebase-navigator/<project-name>.md`) — record only what's unique to this agent's domain, not architecture/conventions/file paths the atlas already covers
+- If you notice your own memory files use a structure from an older version of this section, migrate them to the current structure as part of normal write-back
+
+What to save: after producing the Phase 5 report, write it to `~/.claude/agent-memory/arch-review/<date-slug>.md` (e.g. `2026-03.md`) to enable longitudinal architectural health comparison across review runs.
+
+Update `MEMORY.md` with one line per project + date, linking to the `<date-slug>.md` file.
 
 If `graphify-out/graph.json` exists in the project root, trigger an incremental rebuild:
 ```

--- a/agents/data-flow.md
+++ b/agents/data-flow.md
@@ -289,9 +289,17 @@ POST /api/orders
 - **Orphaned writes are suspicious** — data written to storage and never read is either dead code or a missing consumer; flag it
 - **ASCII flow diagrams are the primary artifact** — they must be readable without context
 
-## Ingestion
+## Persistent Agent Memory
 
-After producing the map, write it to `~/.claude/agent-memory/data-flow/<scope-slug>.md` (e.g. `orders-domain-2026-03.md` or `full-system-2026-03.md`) so future analyses can extend it.
+You have a persistent memory directory at `~/.claude/agent-memory/data-flow/`. Its contents persist across conversations.
+
+Guidelines:
+- **Don't duplicate codebase-navigator's atlas** (`~/.claude/agent-memory/codebase-navigator/<project-name>.md`) — record only what's unique to this agent's domain, not architecture/conventions/file paths the atlas already covers
+- If you notice your own memory files use a structure from an older version of this section, migrate them to the current structure as part of normal write-back
+
+What to save: after producing the map, write it to `~/.claude/agent-memory/data-flow/<scope-slug>.md` (e.g. `orders-domain-2026-03.md` or `full-system-2026-03.md`) so future analyses can extend it.
+
+Update `MEMORY.md` with one line per domain/scope mapped, linking to its `<scope-slug>.md` file.
 
 If `graphify-out/graph.json` exists in the project root, trigger an incremental rebuild:
 ```

--- a/agents/dep-map.md
+++ b/agents/dep-map.md
@@ -21,6 +21,7 @@ Before doing any discovery, check if `codebase-navigator` has already mapped thi
 3. Read `~/.claude/agent-memory/codebase-navigator/MEMORY.md` to see if an atlas exists
 4. If yes, read `~/.claude/agent-memory/codebase-navigator/<project-name>.md` — it gives you stack, architecture, layer map, entry points, and conventions instantly
 5. Skip redundant Phase 1 discovery steps that the atlas already covers
+6. Check `~/.claude/agent-memory/dep-map/` for a prior dependency map of this project — read `MEMORY.md` and the project's entry to see previously identified circular dependencies and layer violations, and whether they were addressed
 
 ### Phase 1: Language & Tooling Detection
 Detect the project's language(s) and dependency format:
@@ -100,6 +101,21 @@ module-c → [] (leaf)
 - Distinguish between internal imports and external package imports
 - For large codebases, focus on module-level mapping first, then drill into specific files if issues arise
 - Always explain *why* a circular dependency or violation is a problem, not just that it exists
+
+## Persistent Agent Memory
+
+You have a persistent memory directory at `~/.claude/agent-memory/dep-map/`. Its contents persist across conversations.
+
+Guidelines:
+- **Don't duplicate codebase-navigator's atlas** (`~/.claude/agent-memory/codebase-navigator/<project-name>.md`) — record only what's unique to this agent's domain, not architecture/conventions/file paths the atlas already covers
+- If you notice your own memory files use a structure from an older version of this section, migrate them to the current structure as part of normal write-back
+
+What to save (in `<project-name>.md`):
+- The dependency graph (module → module relationships) from the most recent mapping
+- Known circular dependencies and whether they've been fixed
+- Layer-violation findings, with dates
+
+Update `MEMORY.md` with one line per project linking to its `<project-name>.md`.
 
 ## Chaining
 

--- a/agents/impact-analysis.md
+++ b/agents/impact-analysis.md
@@ -230,9 +230,17 @@ One sentence stating the overall risk and the single most important thing to do 
 - **Give a concrete checklist** — "What to Test" must be specific file names and commands, not "run the test suite"
 - **Confirm before assuming dead** — if a symbol appears unused, check dynamic references and config before declaring it safe to delete
 
-## Ingestion
+## Persistent Agent Memory
 
-After producing the report, write it to `~/.claude/agent-memory/impact-analysis/<target-slug>.md` (e.g. `getUserById-signature-2026-03.md`) so future analyses can build on it.
+You have a persistent memory directory at `~/.claude/agent-memory/impact-analysis/`. Its contents persist across conversations.
+
+Guidelines:
+- **Don't duplicate codebase-navigator's atlas** (`~/.claude/agent-memory/codebase-navigator/<project-name>.md`) — record only what's unique to this agent's domain, not architecture/conventions/file paths the atlas already covers
+- If you notice your own memory files use a structure from an older version of this section, migrate them to the current structure as part of normal write-back
+
+What to save: after producing the report, write it to `~/.claude/agent-memory/impact-analysis/<target-slug>.md` (e.g. `getUserById-signature-2026-03.md`) so future analyses can build on it.
+
+Update `MEMORY.md` with one line per analyzed target/symbol, linking to its `<target-slug>.md` file.
 
 If `graphify-out/graph.json` exists in the project root, trigger an incremental rebuild:
 ```

--- a/agents/performance.md
+++ b/agents/performance.md
@@ -23,6 +23,7 @@ Before doing any discovery, check if `codebase-navigator` has already mapped thi
 5. Check for an existing knowledge graph: if `graphify-out/graph.json` exists, run `graphify query "What are known performance bottlenecks, caching strategies, and data access patterns in this project?"` and use the results to focus on areas already flagged and avoid re-investigating solved problems.
    If there's no graph or graphify is unavailable, continue — the atlas is sufficient.
 6. Skip redundant Phase 1 discovery steps that the atlas already covers
+7. Check `~/.claude/agent-memory/performance/` for prior performance analyses of this project — read `MEMORY.md` and the project's entry to see previously identified bottlenecks and whether the recommended fixes were applied
 
 ### Phase 1: Scope Definition
 1. What is slow? (specific endpoint, operation, or whole system?)
@@ -117,6 +118,21 @@ If profiling output, slow query logs, or APM data is available:
 - Distinguish between algorithmic problems (fix the code) and infrastructure problems (add caching/scaling)
 - Don't recommend premature optimization — focus on measured or clearly O(n²)+ issues
 - If profiling data is available, always use it; static analysis alone can miss the real bottleneck
+
+## Persistent Agent Memory
+
+You have a persistent memory directory at `~/.claude/agent-memory/performance/`. Its contents persist across conversations.
+
+Guidelines:
+- **Don't duplicate codebase-navigator's atlas** (`~/.claude/agent-memory/codebase-navigator/<project-name>.md`) — record only what's unique to this agent's domain, not architecture/conventions/file paths the atlas already covers
+- If you notice your own memory files use a structure from an older version of this section, migrate them to the current structure as part of normal write-back
+
+What to save (in `<project-name>.md`):
+- Prior findings by severity (Critical/High/Medium) with file:line
+- Whether the "Estimated gain" fix for each finding was applied
+- Hot-path traces already identified, so future runs don't re-trace them
+
+Update `MEMORY.md` with one line per project linking to its `<project-name>.md`.
 
 ## Chaining
 

--- a/agents/root-cause.md
+++ b/agents/root-cause.md
@@ -116,9 +116,17 @@ Symptom → Why 1 → Why 2 → Why 3 → Why 4 → **Root Cause**
 - If you can't determine the root cause from static analysis, say so and explain what runtime data would confirm it
 - Always distinguish between the root cause and contributing factors
 
-## Ingestion
+## Persistent Agent Memory
 
-After producing the Phase 7 report, write it to `~/.claude/agent-memory/root-cause/<incident-slug>.md` (e.g. `payment-unicode-crash-2026-03.md`) so future analyses can benefit from it.
+You have a persistent memory directory at `~/.claude/agent-memory/root-cause/`. Its contents persist across conversations.
+
+Guidelines:
+- **Don't duplicate codebase-navigator's atlas** (`~/.claude/agent-memory/codebase-navigator/<project-name>.md`) — record only what's unique to this agent's domain, not architecture/conventions/file paths the atlas already covers
+- If you notice your own memory files use a structure from an older version of this section, migrate them to the current structure as part of normal write-back
+
+What to save: after producing the Phase 7 report, write it to `~/.claude/agent-memory/root-cause/<incident-slug>.md` (e.g. `payment-unicode-crash-2026-03.md`) so future analyses can benefit from it.
+
+Update `MEMORY.md` with one line per incident, linking to its `<incident-slug>.md` file.
 
 If `graphify-out/graph.json` exists in the project root, trigger an incremental rebuild:
 ```

--- a/agents/security.md
+++ b/agents/security.md
@@ -22,6 +22,7 @@ Before doing any discovery, check if `codebase-navigator` has already mapped thi
 4. If yes, read `~/.claude/agent-memory/codebase-navigator/<project-name>.md` — it gives you stack, auth mechanisms, entry points, and data access patterns instantly
 5. Check for an existing knowledge graph: if `graphify-out/graph.json` exists, run `graphify query "authentication, authorization, and security design"` to surface any documented security decisions, threat models, or known constraints
 6. Skip redundant Phase 1 discovery steps that the atlas already covers
+7. Check `~/.claude/agent-memory/security/` for prior security findings — read `MEMORY.md` and the project's entry as part of orientation to see previously identified vulnerabilities and their remediation status
 
 ### Phase 1: Reconnaissance
 1. Identify the tech stack, framework, and language
@@ -137,6 +138,20 @@ Work through each category systematically:
 - Always provide a concrete fix, not just "sanitize your inputs"
 - Do not report style issues or non-security concerns in this audit
 - If a security control is implemented correctly, note it as a positive finding
+
+## Persistent Agent Memory
+
+You have a persistent memory directory at `~/.claude/agent-memory/security/`. Its contents persist across conversations.
+
+Guidelines:
+- **Don't duplicate codebase-navigator's atlas** (`~/.claude/agent-memory/codebase-navigator/<project-name>.md`) — record only what's unique to this agent's domain, not architecture/conventions/file paths the atlas already covers
+- If you notice your own memory files use a structure from an older version of this section, migrate them to the current structure as part of normal write-back
+
+What to save (in `<project-name>.md`):
+- Prior findings by severity with remediation status (fixed / open / won't-fix)
+- Known-accepted risks the user has reviewed, with reasoning — don't re-flag these as new findings, but include them in the report as "previously reviewed"
+
+Update `MEMORY.md` with one line per project linking to its `<project-name>.md`.
 
 ## Chaining
 

--- a/agents/synthesis.md
+++ b/agents/synthesis.md
@@ -230,9 +230,19 @@ Findings that need more investigation before they can be ranked:
 - **Effort estimates are required** — teams need to know if this is a day of work or a quarter of work before they can plan
 - **Flag coverage gaps** — if no agent covered a critical area (e.g., no performance analysis was run), say so explicitly
 
-## Persistence
+## Persistent Agent Memory
 
-After producing the unified report, write it to `~/.claude/agent-memory/synthesis/<date-slug>.md` (e.g. `pre-release-synthesis-2026-03.md`) so future runs of this agent can find it.
+You have a persistent memory directory at `~/.claude/agent-memory/synthesis/`. Its contents persist across conversations.
+
+Guidelines:
+- **Don't duplicate codebase-navigator's atlas** (`~/.claude/agent-memory/codebase-navigator/<project-name>.md`) — record only what's unique to this agent's domain, not architecture/conventions/file paths the atlas already covers
+- If you notice your own memory files use a structure from an older version of this section, migrate them to the current structure as part of normal write-back
+
+What to save: after producing the unified report, write it to `~/.claude/agent-memory/synthesis/<date-slug>.md` (e.g. `pre-release-synthesis-2026-03.md`) so future runs of this agent can find it.
+
+What NOT to save: the individual agent reports already written to `~/.claude/agent-memory/{security,arch-review,performance,...}/` — synthesis's memory is the *unified* output only, not a copy of its inputs.
+
+Update `MEMORY.md` with one line per synthesis run/date, linking to the `<date-slug>.md` file.
 
 If `graphify-out/graph.json` exists in the project root, trigger an incremental rebuild so the new report is reflected in the graph:
 ```

--- a/agents/tech-debt.md
+++ b/agents/tech-debt.md
@@ -303,9 +303,17 @@ Given the above, the highest-ROI order to tackle this debt is:
 - **Critical paths get higher weight** — debt in the auth module is more dangerous than debt in the reporting module, even if the code quality is identical
 - **Do not flag style issues as debt** — inconsistent formatting, naming preferences, and subjective code style are not technical debt; they have no carrying cost
 
-## Ingestion
+## Persistent Agent Memory
 
-After producing the register, write it to `~/.claude/agent-memory/tech-debt/<date-slug>.md` (e.g. `debt-register-2026-03.md`) so future runs can build on it.
+You have a persistent memory directory at `~/.claude/agent-memory/tech-debt/`. Its contents persist across conversations.
+
+Guidelines:
+- **Don't duplicate codebase-navigator's atlas** (`~/.claude/agent-memory/codebase-navigator/<project-name>.md`) — record only what's unique to this agent's domain, not architecture/conventions/file paths the atlas already covers
+- If you notice your own memory files use a structure from an older version of this section, migrate them to the current structure as part of normal write-back
+
+What to save: after producing the register, write it to `~/.claude/agent-memory/tech-debt/<date-slug>.md` (e.g. `debt-register-2026-03.md`) so future runs can build on it.
+
+Update `MEMORY.md` with one line per project + date, linking to the `<date-slug>.md` file.
 
 If `graphify-out/graph.json` exists in the project root, trigger an incremental rebuild:
 ```


### PR DESCRIPTION
## Summary
- Renames `## Ingestion`/`## Persistence` to the canonical `## Persistent Agent Memory` heading in arch-review, impact-analysis, tech-debt, root-cause, data-flow, and synthesis — keeping each agent's existing write-back instructions as "What to save" and adding the standard guardrails plus a `MEMORY.md` index convention (none previously had one).
- Adds net-new `## Persistent Agent Memory` sections (plus a Phase 0 self-read step) to dep-map, performance, and security, which declared `memory: user` but had zero memory guidance.

Story 2a of epic #12, rolling out the Persistent Agent Memory convention (follows #18 and #19).

## Test plan
- [x] `grep -c "^## Persistent Agent Memory"` → 1 for all 9 agents
- [x] `grep -c "^## Ingestion\|^## Persistence"` → 0 for the 6 renamed agents
- [x] `grep -c "MEMORY.md"` ≥ 1 for all 9 agents
- [x] Both guardrail bullets present in all 9 agents
- [x] `/graphify --update` block survives intact in all 6 renamed sections
- [x] `./install.sh --dry-run` completes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)