### PR TITLE
fix: bump Go toolchain to 1.25.11 to resolve stdlib CVEs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.25"
 
       - uses: goreleaser/goreleaser-action@v6
         with:

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -1,6 +1,6 @@
 module devexp
 
-go 1.21
+go 1.25.11
 
 require (
 	github.com/manifoldco/promptui v0.9.0


### PR DESCRIPTION
## Summary
- Bumps `cli/go.mod`'s `go` directive from `1.21` to `1.25.11`
- Bumps the release workflow's `actions/setup-go` version from `1.21` to `1.25`

govulncheck previously flagged 3 reachable stdlib vulnerabilities:
- GO-2026-5037 (crypto/x509) — fixed in go1.25.11
- GO-2026-4602 (os) — fixed in go1.25.8
- GO-2026-4601 (net/url) — fixed in go1.25.8

Surfaced by `/improve`'s security check after v0.1.0.

## Test plan
- [x] `go build ./...` succeeds (toolchain auto-downloads go1.25.11 via `GOTOOLCHAIN=auto`)
- [x] `go mod tidy` — no changes to go.sum
- [x] `govulncheck ./...` now reports 0 vulnerabilities in code (was 3)
- [x] `go vet ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)