### PR TITLE
refactor: add Persistent Agent Memory section to 8 workflow agents

### DIFF
--- a/agents/changelog.md
+++ b/agents/changelog.md
@@ -19,6 +19,7 @@ Before doing any discovery, check if `codebase-navigator` has already mapped thi
 1. Run `git rev-parse --show-toplevel 2>/dev/null || pwd` to get the project root
 2. Read `~/.claude/agent-memory/codebase-navigator/MEMORY.md` to see if an atlas exists
 3. If yes, read the atlas for stack context (language, version file locations)
+4. Check `~/.claude/agent-memory/changelog/MEMORY.md` for this project — prior runs may have recorded the last-generated version/tag and any non-conventional-commit patterns that needed special-casing
 
 ### Phase 1: Determine Scope
 Identify the range to generate a changelog for:
@@ -200,6 +201,20 @@ Written to: CHANGELOG.md (or "output to release platform format")
 - If a commit message is unclear or doesn't follow conventional commits, include it under the most appropriate section with a note
 - If the commit range is empty (nothing changed), say so clearly — do not generate an empty section
 - Always include commit SHA links so users can inspect the actual change
+
+## Persistent Agent Memory
+
+You have a persistent memory directory at `~/.claude/agent-memory/changelog/`. Its contents persist across conversations.
+
+Guidelines:
+- **Don't duplicate codebase-navigator's atlas** (`~/.claude/agent-memory/codebase-navigator/<project-name>.md`) — record only what's unique to this agent's domain, not architecture/conventions/file paths the atlas already covers
+- If you notice your own memory files use a structure from an older version of this section, migrate them to the current structure as part of normal write-back
+
+What to save (in `<project-name>.md`):
+- The last-generated version/tag and the date it was generated — avoids re-deriving the full tag list on repeat runs
+- Any non-conventional-commit patterns this project uses that needed special-casing during parsing
+
+Update `MEMORY.md` with one line per project linking to its `<project-name>.md`.
 
 ## Chaining
 

--- a/agents/ci-cd.md
+++ b/agents/ci-cd.md
@@ -28,6 +28,7 @@ Before doing any discovery, check if `codebase-navigator` has already mapped thi
 2. Derive the project name from the root directory name
 3. Read `~/.claude/agent-memory/codebase-navigator/MEMORY.md` to see if an atlas exists
 4. If yes, read `~/.claude/agent-memory/codebase-navigator/<project-name>.md` — it gives you the stack, test commands, and build tooling instantly
+5. Check `~/.claude/agent-memory/ci-cd/MEMORY.md` for prior pipeline diagnoses on this project — known-flaky steps and the required secrets list avoid re-derivation
 
 ### Phase 1: Discovery
 Always read all pipeline configuration before making any change:
@@ -257,6 +258,21 @@ Configure these in: Settings → Secrets and variables → Actions
 - When adding a step, match the YAML style of the surrounding file exactly
 - If a pipeline is fundamentally broken, fix the critical issue first — don't optimize a broken pipeline
 - Always validate YAML syntax before reporting done
+
+## Persistent Agent Memory
+
+You have a persistent memory directory at `~/.claude/agent-memory/ci-cd/`. Its contents persist across conversations.
+
+Guidelines:
+- **Don't duplicate codebase-navigator's atlas** (`~/.claude/agent-memory/codebase-navigator/<project-name>.md`) — record only what's unique to this agent's domain, not architecture/conventions/file paths the atlas already covers
+- If you notice your own memory files use a structure from an older version of this section, migrate them to the current structure as part of normal write-back
+
+What to save (in `<project-name>.md`):
+- Prior pipeline failures and their root causes
+- Known-flaky CI steps
+- The project's required secrets list — avoid re-deriving it on every pipeline change
+
+Update `MEMORY.md` with one line per project linking to its `<project-name>.md`.
 
 ## Chaining
 

--- a/agents/onboarding.md
+++ b/agents/onboarding.md
@@ -322,6 +322,20 @@ After writing the file, report the path and offer to generate guides for adjacen
 - **Known debt section prevents churn** — engineers who know what's intentionally broken stop trying to fix it
 - **Do not fabricate history** — if git log doesn't explain why something was done, say "origin unknown" rather than guessing
 
+## Persistent Agent Memory
+
+You have a persistent memory directory at `~/.claude/agent-memory/onboarding/`. Its contents persist across conversations — see Phase 0 step 5 above for the read half of this workflow.
+
+Guidelines:
+- **Don't duplicate codebase-navigator's atlas** (`~/.claude/agent-memory/codebase-navigator/<project-name>.md`) — record only what's unique to this agent's domain, not architecture/conventions/file paths the atlas already covers
+- If you notice your own memory files use a structure from an older version of this section, migrate them to the current structure as part of normal write-back
+
+What to save (in `<project-name>.md`):
+- Which modules already have a generated guide, and when — avoids regenerating a guide that's still current
+- Historical Context findings that took git-archaeology to discover — the highest-value, hardest-to-rederive content in any guide
+
+Update `MEMORY.md` with one line per project linking to its `<project-name>.md`.
+
 ## Chaining
 
 - **For modules with significant debt** → suggest running `tech-debt` agent on the module

--- a/agents/postmortem.md
+++ b/agents/postmortem.md
@@ -24,6 +24,7 @@ Before writing, check if root-cause analysis was already performed:
    find . -name "POSTMORTEM*" -o -path "*/postmortems/*" 2>/dev/null | head -20
    ```
 5. If existing postmortems are found, read one as a style reference
+6. Check `~/.claude/agent-memory/postmortem/MEMORY.md` for prior incidents on this project — recurring root causes across incidents are a signal worth surfacing
 
 ### Phase 1: Gather Incident Information
 Collect the following before writing. If the user didn't provide all of it, infer from context, check git logs, and ask only for what's truly missing:
@@ -246,6 +247,20 @@ Update the postmortem's action items table with the created ticket numbers/URLs.
 - The timeline must be chronological and in a consistent timezone
 - Always include a "where we got lucky" section — this is often where the most valuable prevention work is found
 - A postmortem is not a punishment document — it is a learning artifact
+
+## Persistent Agent Memory
+
+You have a persistent memory directory at `~/.claude/agent-memory/postmortem/`. Its contents persist across conversations.
+
+Guidelines:
+- **Don't duplicate codebase-navigator's atlas** (`~/.claude/agent-memory/codebase-navigator/<project-name>.md`) — record only what's unique to this agent's domain, not architecture/conventions/file paths the atlas already covers
+- If you notice your own memory files use a structure from an older version of this section, migrate them to the current structure as part of normal write-back
+
+What to save (in `<project-name>.md`):
+- Prior incident titles, dates, and root causes (one entry per incident) — recurring root causes across incidents are a strong signal
+- Action items from prior postmortems and whether they were completed — follow-through tracking surfaces unaddressed risk
+
+Update `MEMORY.md` with one line per project linking to its `<project-name>.md`.
 
 ## Chaining
 

--- a/agents/project-manager.md
+++ b/agents/project-manager.md
@@ -20,6 +20,7 @@ Before doing any discovery, check if `codebase-navigator` has already mapped thi
 2. Derive the project name from the root directory name
 3. Read `~/.claude/agent-memory/codebase-navigator/MEMORY.md` to see if an atlas exists
 4. If yes, read `~/.claude/agent-memory/codebase-navigator/<project-name>.md` — it gives you the module structure, stack, and domain context needed to write accurate tickets
+5. Check `~/.claude/agent-memory/project-manager/MEMORY.md` for this project's detected ticket platform and established label vocabulary — avoids re-running Phase 0.5 detection and re-deriving the label taxonomy
 
 ### Phase 0.5: Detect Issue Tracker Platform
 
@@ -175,6 +176,21 @@ Use these conventional labels consistently:
 - For decomposed epics: always create the dependency graph before creating tickets
 - Use the detected platform's CLI or MCP for all interactions — do not produce markdown to paste manually unless no platform is detected
 - If the platform CLI is not authenticated or the MCP is unavailable, report this clearly and output formatted ticket markdown the user can file manually
+
+## Persistent Agent Memory
+
+You have a persistent memory directory at `~/.claude/agent-memory/project-manager/`. Its contents persist across conversations.
+
+Guidelines:
+- **Don't duplicate codebase-navigator's atlas** (`~/.claude/agent-memory/codebase-navigator/<project-name>.md`) — record only what's unique to this agent's domain, not architecture/conventions/file paths the atlas already covers
+- If you notice your own memory files use a structure from an older version of this section, migrate them to the current structure as part of normal write-back
+
+What to save (in `<project-name>.md`):
+- The detected issue tracker platform (Phase 0.5) — cache the result so it doesn't need re-detecting on every call
+- The established label vocabulary for this project, once it diverges from or extends the default (Label Vocabulary section above)
+- Prior epic decomposition decisions and the dependency graphs produced for them
+
+Update `MEMORY.md` with one line per project linking to its `<project-name>.md`.
 
 ## Chaining
 

--- a/agents/scaffold.md
+++ b/agents/scaffold.md
@@ -23,6 +23,7 @@ Before generating anything:
 5. If no atlas exists: run a targeted orientation (see Phase 1 fallback) before proceeding — do not skip this
 6. Check for an existing knowledge graph: if `graphify-out/graph.json` exists, run `graphify query "<type being scaffolded> conventions naming pattern error handling test style"` (e.g. `"service naming error handling"`, `"React component test style"`) and use the results to refine pattern extraction before Phase 2.
    If there's no graph or graphify is unavailable, continue with the atlas and canonical examples.
+7. Check `~/.claude/agent-memory/scaffold/MEMORY.md` for which canonical examples were used for which pattern in this project last time — but still re-read each file in Phase 2 (Core Principle: Read Before You Write) to catch drift since the file paths were recorded
 
 ### Phase 1: Orientation (if no atlas)
 If the codebase-navigator atlas does not exist:
@@ -138,6 +139,22 @@ Produce a clear summary:
 - Do not generate a generic template — if a pattern doesn't fit, ask before inventing
 - If the codebase has no examples of what's being scaffolded, say so and ask for guidance on which existing pattern is closest
 - If 2-3 canonical examples disagree on a pattern (inconsistency in the codebase), choose the most recent one and note the inconsistency
+
+## Persistent Agent Memory
+
+You have a persistent memory directory at `~/.claude/agent-memory/scaffold/`. Its contents persist across conversations.
+
+Guidelines:
+- **Don't duplicate codebase-navigator's atlas** (`~/.claude/agent-memory/codebase-navigator/<project-name>.md`) — record only what's unique to this agent's domain, not architecture/conventions/file paths the atlas already covers
+- If you notice your own memory files use a structure from an older version of this section, migrate them to the current structure as part of normal write-back
+
+What to save (in `<project-name>.md`):
+- The file paths of canonical examples chosen for each pattern (e.g., "for new services, `packages/api/services/orders.go` was the canonical example") — speeds up Phase 2 on repeat scaffolds
+
+What NOT to save:
+- The *content* of canonical examples — Core Principle: Read Before You Write still requires re-reading the actual file each time to catch drift; memory only points to where to look, never substitutes for the read
+
+Update `MEMORY.md` with one line per project linking to its `<project-name>.md`.
 
 ## Chaining
 

--- a/agents/tech-lead.md
+++ b/agents/tech-lead.md
@@ -27,6 +27,7 @@ Before any technical assessment or document:
    find . -path "*/decisions/*" -name "*.md" 2>/dev/null | sort
    ```
 7. Read any existing ADRs to understand the decision-making history and established patterns
+8. Check `~/.claude/agent-memory/tech-lead/MEMORY.md` for an index of prior ADRs and decisions on this project — new design reviews and ADRs must check for conflicts with these before proceeding
 
 ### Phase 1: Classify the Request
 
@@ -459,6 +460,20 @@ Save to `docs/architecture/<domain>-schema.md` or alongside the migration file.
 - Design reviews must be specific: "this won't scale" is not feedback; "this design performs N database queries per request and will hit connection pool limits at ~5K RPS based on current pool size of 20" is feedback
 - Standards must be grounded in existing code — don't impose patterns the codebase doesn't already use successfully
 - When the right answer is genuinely unclear, say so and explain what information would resolve the ambiguity
+
+## Persistent Agent Memory
+
+You have a persistent memory directory at `~/.claude/agent-memory/tech-lead/`. Its contents persist across conversations.
+
+Guidelines:
+- **Don't duplicate codebase-navigator's atlas** (`~/.claude/agent-memory/codebase-navigator/<project-name>.md`) — record only what's unique to this agent's domain, not architecture/conventions/file paths the atlas already covers
+- If you notice your own memory files use a structure from an older version of this section, migrate them to the current structure as part of normal write-back
+
+What to save (in `<project-name>.md`):
+- An index of prior ADRs: title, status, date, and file path under `docs/adr/` or `docs/decisions/` — so new design reviews can check for conflicts with prior decisions
+- Prior trade-off analyses and their outcomes
+
+Update `MEMORY.md` with one line per project linking to its `<project-name>.md`.
 
 ## Chaining
 

--- a/agents/test-runner.md
+++ b/agents/test-runner.md
@@ -21,6 +21,7 @@ Before doing any discovery, check if `codebase-navigator` has already mapped thi
 3. Read `~/.claude/agent-memory/codebase-navigator/MEMORY.md` to see if an atlas exists
 4. If yes, read `~/.claude/agent-memory/codebase-navigator/<project-name>.md` — the "Test Conventions" section tells you the framework, test locations, and helpers instantly
 5. Skip redundant Phase 1 discovery steps that the atlas already covers
+6. Check `~/.claude/agent-memory/test-runner/MEMORY.md` for known-flaky tests and prior coverage baselines on this project
 
 ### Phase 1: Discovery
 1. Identify the test framework and test runner:
@@ -125,6 +126,20 @@ For each failing test:
 - Distinguish between "the test is wrong" and "the code is wrong"
 - For coverage: focus on uncovered critical paths, not raw percentage
 - For flaky tests: run at least 3 times to confirm flakiness
+
+## Persistent Agent Memory
+
+You have a persistent memory directory at `~/.claude/agent-memory/test-runner/`. Its contents persist across conversations.
+
+Guidelines:
+- **Don't duplicate codebase-navigator's atlas** (`~/.claude/agent-memory/codebase-navigator/<project-name>.md`) — record only what's unique to this agent's domain, not architecture/conventions/file paths the atlas already covers
+- If you notice your own memory files use a structure from an older version of this section, migrate them to the current structure as part of normal write-back
+
+What to save (in `<project-name>.md`):
+- Known-flaky tests, with their flake rate and the date last confirmed
+- Coverage baseline over time — track the trend, not just the latest number
+
+Update `MEMORY.md` with one line per project linking to its `<project-name>.md`.
 
 ## Chaining
 


### PR DESCRIPTION
## Summary
- Closes #15
- Adds the canonical `## Persistent Agent Memory` section (per `templates/agent-template.md`) to 8 workflow-category agents: `changelog`, `ci-cd`, `onboarding`, `postmortem`, `project-manager`, `scaffold`, `test-runner`, `tech-lead`
- Each agent gets a Phase-0 read step plus agent-specific "what to save" / "what NOT to save" guidance (e.g. scaffold caches canonical-example *paths* only, never content)
- `onboarding`'s existing Phase-0 read step (step 5) is preserved unchanged; only the write-back half was added
- Continues the pattern established in #19 and #20

## Test plan
- [x] `grep -c "^## Persistent Agent Memory" agents/{changelog,ci-cd,onboarding,postmortem,project-manager,scaffold,test-runner,tech-lead}.md` — all output `1`
- [x] `grep -c "MEMORY.md"` — all ≥ 1
- [x] `grep -c "Don't duplicate codebase-navigator's atlas\|migrate them to the current structure"` — all = 2
- [x] `agents/onboarding.md` has exactly 2 references to `agent-memory/onboarding` (no duplicate read instructions)
- [x] `./install.sh --dry-run` completes cleanly for all 34 agents on both platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)