### PR TITLE
docs: add memory section checklist item to Agent File Checklist

### DIFF
--- a/docs/development/agent-architecture-reference.md
+++ b/docs/development/agent-architecture-reference.md
@@ -214,3 +214,4 @@ Before submitting a new agent file, verify:
 - [ ] If Phase 0 reads `## Known Technical Debt`/`## Gotchas` from the atlas, step 4a's freshness check is applied before repeating any claim
 - [ ] All tools in `tools:` frontmatter are actually used in the body
 - [ ] Installed via `./install.sh` after changes
+- [ ] If frontmatter has `memory: user`, the body has a `## Persistent Agent Memory` section consistent with [Memory Convention](#memory-convention) — including the "don't duplicate the atlas" and "self-heal format drift" guardrails — and vice versa (no `## Persistent Agent Memory` section without `memory: user` in frontmatter)


### PR DESCRIPTION
## Summary
- Adds a 10th item to the Agent File Checklist in `docs/development/agent-architecture-reference.md`: if an agent's frontmatter has `memory: user`, its body must have a `## Persistent Agent Memory` section consistent with [Memory Convention](docs/development/agent-architecture-reference.md#memory-convention) (including the "don't duplicate the atlas" and "self-heal format drift" guardrails) — and vice versa.
- This wires the existing `## Memory Convention` section (lines 189-200) into the per-file review checklist, closing the gap that let 25/27 agents drift.

## Test plan
- [x] `grep -n "Memory Convention"` shows both the existing heading (line 189) and the new cross-reference in the checklist item
- [x] `grep -c "^- \[ \]"` returns 10 (was 9) within the Agent File Checklist section
- [x] Anchor `#memory-convention` resolves to the existing `## Memory Convention` heading (GitHub auto-generates lowercase-hyphenated anchors)

Closes #16