### PR TITLE
docs: add agent-memory duplication mapping convention

### DIFF
--- a/docs/development/agent-architecture-reference.md
+++ b/docs/development/agent-architecture-reference.md
@@ -199,6 +199,21 @@ Agents with `memory: user` in frontmatter have a persistent memory directory at 
 - **Don't duplicate the atlas**: if Phase 0 already reads `~/.claude/agent-memory/codebase-navigator/<project>.md`, your memory should hold only what that atlas doesn't — your agent's own domain-specific findings (e.g., prior trace results, prior audit findings, prior groomed tickets), not architecture, layer maps, conventions, or file paths the atlas already covers.
 - **Self-heal format drift**: if your memory files (atlas, `MEMORY.md`, or topic files) use section names or structures from a previous version of this convention, migrate them to the current structure as part of your normal write-back for that session — don't perpetuate an outdated format indefinitely. codebase-navigator's Memory Protocol Migration Pass is the concrete implementation of this for atlases.
 
+### Cross-Agent Duplication Mapping
+
+`~/.claude/agent-memory/graphify-out/` holds an optional knowledge graph built over the **entire agent-memory corpus** (across all agents and projects) — distinct from a per-project `graphify-out/`. Its purpose is to surface cross-agent duplication: cases where multiple agents' memory files reference the same project artifact (e.g. two agents both pointing at `codebase-navigator/<project>.md`'s atlas), which is a signal that context could be consolidated into the shared atlas instead of repeated per-agent.
+
+**When to run:** manually, via `/improve` — not hooked to memory writes. At current write volumes (a handful of agents writing memory across a couple of projects), the signal-to-cost ratio favors periodic manual runs over an automated hook.
+
+**How to run:**
+```bash
+/graphify ~/.claude/agent-memory
+```
+
+**Backend:** prefer the Gemini backend (set `GEMINI_API_KEY` or `GOOGLE_API_KEY`) — a 23-file/~24K-word run completed in ~57s at ~50K tokens via Gemini, versus ~288s at ~74K tokens via the Claude-subagent fallback for a smaller 7-file sample. Both produce the same signal; Gemini is materially cheaper and faster for this corpus size.
+
+**Reading the output:** the `## Surprising Connections` section of `graphify-out/GRAPH_REPORT.md` is the primary signal — cross-agent references there indicate memory that could be consolidated into a shared atlas rather than duplicated per-agent.
+
 ---
 
 ## Agent File Checklist

--- a/skills/improve/SKILL.md
+++ b/skills/improve/SKILL.md
@@ -237,6 +237,16 @@ grep -rn "\.catch(" . 2>/dev/null | grep -v node_modules | grep -v test | wc -l
 
 For each divergence found: flag which pattern appears more frequently as the canonical one and list the files using the non-canonical approach as candidates for standardization.
 
+**Agent-memory duplication check:**
+
+```bash
+ls ~/.claude/agent-memory/graphify-out/graph.json 2>/dev/null && echo "graph: EXISTS" || echo "graph: not built yet"
+```
+
+If the graph exists: run `/graphify ~/.claude/agent-memory --update` to refresh it, then read the `## Surprising Connections` section of `~/.claude/agent-memory/graphify-out/GRAPH_REPORT.md`. Each cross-agent reference there is a candidate for consolidation into a shared atlas (`codebase-navigator/<project>.md`) instead of duplication per-agent.
+
+If the graph doesn't exist: note it as a one-time optional setup step — see [Cross-Agent Duplication Mapping](../../docs/development/agent-architecture-reference.md#cross-agent-duplication-mapping). Don't build it on `/improve`'s own initiative; the first run is user-directed.
+
 Present findings as a cleanup checklist:
 ```
 Stale work found:
@@ -248,6 +258,9 @@ Stale work found:
 
 Convention divergence found:
   <pattern type>: N files use canonical, M files use non-canonical — list non-canonical files
+
+Agent-memory duplication found:
+  <N cross-agent references> (suggest: consolidate into shared atlas — list source → target pairs)
 ```
 
 Do not delete anything automatically — surface findings only.


### PR DESCRIPTION
## Summary
- Revisits #17/#26 now that `GEMINI_API_KEY`/`GOOGLE_API_KEY` is available — the cost concern that justified deferral is resolved (23 files/~24K words in 57s @ ~50K tokens vs 7 files in ~288s @ ~74K tokens via Claude subagent fallback)
- Documents `~/.claude/agent-memory/graphify-out/` as the convention for cross-agent duplication mapping in `docs/development/agent-architecture-reference.md`
- Adds a manual "Agent-memory duplication check" step to `/improve` Phase 3 (not hooked — write frequency is still low)

## Test plan
- [x] Spike re-run validated on the live `~/.claude/agent-memory/` corpus via Gemini backend (see #26 comment for full results)
- [x] Docs-only change — no code/tests affected

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)