### PR TITLE
feat: clean up stale agents/skills/hooks on devexp install updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,11 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version: "1.25"
+          cache-dependency-path: cli/go.sum
       - name: stage assets
         run: ./scripts/stage-assets.sh
       - name: go test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,15 +12,16 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: "1.25"
+          cache-dependency-path: cli/go.sum
 
-      - uses: goreleaser/goreleaser-action@v6
+      - uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser
           version: "~> v2"

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -14,6 +14,7 @@ import (
 	"devexp/internal/agents"
 	"devexp/internal/config"
 	"devexp/internal/hooks"
+	"devexp/internal/manifest"
 	"devexp/internal/mcp"
 	"devexp/internal/repo"
 	"devexp/internal/skills"
@@ -364,11 +365,15 @@ func doInstallClaude(opts *installOpts) error {
 		}
 	}
 
+	manifestPath := filepath.Join(home, ".claude", ".devexp-manifest.json")
+	old, _ := manifest.Load(manifestPath)
+	newManifest := &manifest.Manifest{Agents: old.Agents, Skills: old.Skills}
+
 	if !opts.skillsOnly {
 		backupExisting(agentsTarget, "*.md", backupDir, opts.dryRun)
 		ui.Info("Installing agents...")
 		disabled := resolveAgentDisabled(opts.repoDir, opts.selectedAgents, opts.cfg.DisabledAgents)
-		count, err := agents.InstallClaude(
+		installedAgents, err := agents.InstallClaude(
 			filepath.Join(opts.repoDir, "agents"),
 			agentsTarget,
 			opts.cfg.Model,
@@ -378,13 +383,17 @@ func doInstallClaude(opts *installOpts) error {
 		if err != nil {
 			return err
 		}
-		ui.Success(fmt.Sprintf("Installed %d agent(s).", count))
+		ui.Success(fmt.Sprintf("Installed %d agent(s).", len(installedAgents)))
 		fmt.Println()
+
+		newManifest.Agents = installedAgents
+		removeStale(agentsTarget, manifest.Stale(old.Agents, installedAgents), os.Remove, opts.dryRun)
 	}
 
 	if !opts.agentsOnly {
+		backupExistingDirs(skillsTarget, backupDir, opts.dryRun)
 		ui.Info("Installing skills...")
-		count, err := skills.InstallClaude(
+		installedSkills, err := skills.InstallClaude(
 			filepath.Join(opts.repoDir, "skills"),
 			skillsTarget,
 			opts.cfg.DisabledSkills,
@@ -393,8 +402,11 @@ func doInstallClaude(opts *installOpts) error {
 		if err != nil {
 			return err
 		}
-		ui.Success(fmt.Sprintf("Installed %d skill(s).", count))
+		ui.Success(fmt.Sprintf("Installed %d skill(s).", len(installedSkills)))
 		fmt.Println()
+
+		newManifest.Skills = installedSkills
+		removeStale(skillsTarget, manifest.Stale(old.Skills, installedSkills), os.RemoveAll, opts.dryRun)
 	}
 
 	if !opts.agentsOnly && !opts.skillsOnly {
@@ -408,6 +420,12 @@ func doInstallClaude(opts *installOpts) error {
 				return err
 			}
 			fmt.Println()
+		}
+	}
+
+	if !opts.dryRun {
+		if err := manifest.Save(manifestPath, newManifest); err != nil {
+			ui.Warn(fmt.Sprintf("save manifest: %v", err))
 		}
 	}
 
@@ -445,10 +463,14 @@ func doInstallOpencode(opts *installOpts) error {
 		}
 	}
 
+	manifestPath := filepath.Join(home, ".config", "opencode", ".devexp-manifest.json")
+	old, _ := manifest.Load(manifestPath)
+	newManifest := &manifest.Manifest{Agents: old.Agents, Skills: old.Skills}
+
 	if !opts.skillsOnly {
 		ui.Info("Installing agents (transformed for opencode)...")
 		disabled := resolveAgentDisabled(opts.repoDir, opts.selectedAgents, opts.cfg.DisabledAgents)
-		count, err := agents.InstallOpencode(
+		installedAgents, err := agents.InstallOpencode(
 			filepath.Join(opts.repoDir, "agents"),
 			agentsTarget,
 			opts.cfg.Model,
@@ -458,7 +480,7 @@ func doInstallOpencode(opts *installOpts) error {
 		if err != nil {
 			return err
 		}
-		excl, err := agents.InstallOpencodeExclusive(
+		installedExclusive, err := agents.InstallOpencodeExclusive(
 			filepath.Join(opts.repoDir, "agents", "opencode"),
 			agentsTarget,
 			opts.cfg.Model,
@@ -467,13 +489,17 @@ func doInstallOpencode(opts *installOpts) error {
 		if err != nil {
 			return err
 		}
-		ui.Success(fmt.Sprintf("Installed %d agent(s).", count+excl))
+		allInstalledAgents := append(installedAgents, installedExclusive...)
+		ui.Success(fmt.Sprintf("Installed %d agent(s).", len(allInstalledAgents)))
 		fmt.Println()
+
+		newManifest.Agents = allInstalledAgents
+		removeStale(agentsTarget, manifest.Stale(old.Agents, allInstalledAgents), os.Remove, opts.dryRun)
 	}
 
 	if !opts.agentsOnly {
 		ui.Info("Installing skills (to ~/.config/opencode/commands)...")
-		count, err := skills.InstallOpencode(
+		installedSkills, err := skills.InstallOpencode(
 			filepath.Join(opts.repoDir, "skills"),
 			skillsTarget,
 			opts.cfg.DisabledSkills,
@@ -482,8 +508,22 @@ func doInstallOpencode(opts *installOpts) error {
 		if err != nil {
 			return err
 		}
-		ui.Success(fmt.Sprintf("Installed %d skill(s).", count))
+		ui.Success(fmt.Sprintf("Installed %d skill(s).", len(installedSkills)))
 		fmt.Println()
+
+		newManifest.Skills = installedSkills
+		staleSkills := manifest.Stale(old.Skills, installedSkills)
+		staleSkillFiles := make([]string, len(staleSkills))
+		for i, s := range staleSkills {
+			staleSkillFiles[i] = s + ".md"
+		}
+		removeStale(skillsTarget, staleSkillFiles, os.Remove, opts.dryRun)
+	}
+
+	if !opts.dryRun {
+		if err := manifest.Save(manifestPath, newManifest); err != nil {
+			ui.Warn(fmt.Sprintf("save manifest: %v", err))
+		}
 	}
 
 	ui.Success("opencode installation complete.")
@@ -674,5 +714,49 @@ func backupExisting(dir, pattern, backupDir string, dryRun bool) {
 			continue
 		}
 		os.WriteFile(filepath.Join(backupDir, filepath.Base(src)), data, 0644) //nolint:errcheck
+	}
+}
+
+// backupExistingDirs copies pre-existing skill directories (immediate
+// subdirectories of dir containing a SKILL.md) into backupDir/<name>/.
+func backupExistingDirs(dir, backupDir string, dryRun bool) {
+	if dryRun {
+		return
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return
+	}
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		srcDir := filepath.Join(dir, name)
+		if _, err := os.Stat(filepath.Join(srcDir, "SKILL.md")); err != nil {
+			continue
+		}
+		if err := os.MkdirAll(backupDir, 0755); err != nil {
+			return
+		}
+		skills.CopyDir(srcDir, filepath.Join(backupDir, name)) //nolint:errcheck
+	}
+}
+
+// removeStale removes each entry in stale from dir via removeFn (file or
+// dir), reporting via ui. In dry-run mode it only reports what would be
+// removed.
+func removeStale(dir string, stale []string, removeFn func(path string) error, dryRun bool) {
+	for _, name := range stale {
+		path := filepath.Join(dir, name)
+		if dryRun {
+			ui.DryRun(fmt.Sprintf("remove %s (no longer in this release)", path))
+			continue
+		}
+		if err := removeFn(path); err != nil && !os.IsNotExist(err) {
+			ui.Warn(fmt.Sprintf("remove %s: %v", path, err))
+			continue
+		}
+		ui.Removed(name)
 	}
 }

--- a/cli/cmd/install_test.go
+++ b/cli/cmd/install_test.go
@@ -378,6 +378,131 @@ func TestBackupExisting(t *testing.T) {
 	})
 }
 
+func TestBackupExistingDirs(t *testing.T) {
+	t.Run("copies skill dirs containing SKILL.md to backupDir", func(t *testing.T) {
+		dir := t.TempDir()
+		backupDir := filepath.Join(t.TempDir(), "backup")
+
+		alpha := filepath.Join(dir, "alpha")
+		if err := os.MkdirAll(filepath.Join(alpha, "references"), 0755); err != nil {
+			t.Fatalf("MkdirAll() error = %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(alpha, "SKILL.md"), []byte("alpha skill"), 0644); err != nil {
+			t.Fatalf("WriteFile() error = %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(alpha, "references", "notes.md"), []byte("notes"), 0644); err != nil {
+			t.Fatalf("WriteFile() error = %v", err)
+		}
+
+		notASkill := filepath.Join(dir, "not-a-skill")
+		if err := os.MkdirAll(notASkill, 0755); err != nil {
+			t.Fatalf("MkdirAll() error = %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(notASkill, "notes.txt"), []byte("no SKILL.md here"), 0644); err != nil {
+			t.Fatalf("WriteFile() error = %v", err)
+		}
+
+		backupExistingDirs(dir, backupDir, false)
+
+		got, err := os.ReadFile(filepath.Join(backupDir, "alpha", "SKILL.md"))
+		if err != nil {
+			t.Fatalf("ReadFile(backup alpha/SKILL.md) error = %v", err)
+		}
+		if string(got) != "alpha skill" {
+			t.Errorf("backed up SKILL.md content = %q, want %q", got, "alpha skill")
+		}
+		if _, err := os.Stat(filepath.Join(backupDir, "alpha", "references", "notes.md")); err != nil {
+			t.Errorf("nested reference file not backed up: %v", err)
+		}
+		if _, err := os.Stat(filepath.Join(backupDir, "not-a-skill")); !os.IsNotExist(err) {
+			t.Errorf("not-a-skill should not have been backed up, stat err = %v", err)
+		}
+	})
+
+	t.Run("dry run does not create backupDir", func(t *testing.T) {
+		dir := t.TempDir()
+		backupDir := filepath.Join(t.TempDir(), "backup")
+
+		alpha := filepath.Join(dir, "alpha")
+		if err := os.MkdirAll(alpha, 0755); err != nil {
+			t.Fatalf("MkdirAll() error = %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(alpha, "SKILL.md"), []byte("alpha skill"), 0644); err != nil {
+			t.Fatalf("WriteFile() error = %v", err)
+		}
+
+		backupExistingDirs(dir, backupDir, true)
+
+		if _, err := os.Stat(backupDir); !os.IsNotExist(err) {
+			t.Errorf("backupDir should not exist in dry run, stat err = %v", err)
+		}
+	})
+
+	t.Run("no skill dirs does not create backupDir", func(t *testing.T) {
+		dir := t.TempDir()
+		backupDir := filepath.Join(t.TempDir(), "backup")
+
+		backupExistingDirs(dir, backupDir, false)
+
+		if _, err := os.Stat(backupDir); !os.IsNotExist(err) {
+			t.Errorf("backupDir should not exist when no skill dirs found, stat err = %v", err)
+		}
+	})
+}
+
+func TestRemoveStale(t *testing.T) {
+	t.Run("dry run reports without removing", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "stale.md")
+		if err := os.WriteFile(path, []byte("content"), 0644); err != nil {
+			t.Fatalf("WriteFile() error = %v", err)
+		}
+
+		removeStale(dir, []string{"stale.md"}, os.Remove, true)
+
+		if _, err := os.Stat(path); err != nil {
+			t.Errorf("dry run should not remove %s, stat err = %v", path, err)
+		}
+	})
+
+	t.Run("removes entries via removeFn", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "stale.md")
+		if err := os.WriteFile(path, []byte("content"), 0644); err != nil {
+			t.Fatalf("WriteFile() error = %v", err)
+		}
+
+		removeStale(dir, []string{"stale.md"}, os.Remove, false)
+
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Errorf("expected %s to be removed, stat err = %v", path, err)
+		}
+	})
+
+	t.Run("removes directories via os.RemoveAll", func(t *testing.T) {
+		dir := t.TempDir()
+		skillDir := filepath.Join(dir, "old-skill")
+		if err := os.MkdirAll(filepath.Join(skillDir, "references"), 0755); err != nil {
+			t.Fatalf("MkdirAll() error = %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("old"), 0644); err != nil {
+			t.Fatalf("WriteFile() error = %v", err)
+		}
+
+		removeStale(dir, []string{"old-skill"}, os.RemoveAll, false)
+
+		if _, err := os.Stat(skillDir); !os.IsNotExist(err) {
+			t.Errorf("expected %s to be removed, stat err = %v", skillDir, err)
+		}
+	})
+
+	t.Run("tolerates already-missing entries", func(t *testing.T) {
+		dir := t.TempDir()
+
+		removeStale(dir, []string{"already-gone.md"}, os.Remove, false)
+	})
+}
+
 func TestRunRemove(t *testing.T) {
 	t.Run("missing uninstall.sh returns error", func(t *testing.T) {
 		repoDir := t.TempDir()

--- a/cli/internal/agents/installer.go
+++ b/cli/internal/agents/installer.go
@@ -46,13 +46,15 @@ func resolveModel(alias string) string {
 	return alias
 }
 
-// InstallClaude copies agent .md files into targetDir with an optional model override.
-func InstallClaude(srcDir, targetDir, model string, disabled []string, dryRun bool) (int, error) {
+// InstallClaude copies agent .md files into targetDir with an optional model
+// override. Returns the filenames installed (including in dryRun mode), so
+// callers can diff against a manifest to detect stale files from prior runs.
+func InstallClaude(srcDir, targetDir, model string, disabled []string, dryRun bool) ([]string, error) {
 	entries, err := os.ReadDir(srcDir)
 	if err != nil {
-		return 0, err
+		return nil, err
 	}
-	count := 0
+	var installed []string
 	for _, entry := range entries {
 		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".md") {
 			continue
@@ -69,36 +71,38 @@ func InstallClaude(srcDir, targetDir, model string, disabled []string, dryRun bo
 		dest := filepath.Join(targetDir, name)
 		if dryRun {
 			ui.DryRun(fmt.Sprintf("write %s", dest))
-			count++
+			installed = append(installed, name)
 			continue
 		}
 		content, err := os.ReadFile(filepath.Join(srcDir, name))
 		if err != nil {
-			return count, err
+			return installed, err
 		}
 		if model != "" {
 			resolved := resolveModel(model)
 			content = modelRe.ReplaceAll(content, []byte("model: "+resolved))
 		}
 		if err := os.MkdirAll(targetDir, 0755); err != nil {
-			return count, err
+			return installed, err
 		}
 		if err := os.WriteFile(dest, content, 0644); err != nil {
-			return count, err
+			return installed, err
 		}
 		ui.Added(name)
-		count++
+		installed = append(installed, name)
 	}
-	return count, nil
+	return installed, nil
 }
 
-// InstallOpencode transforms agent files for opencode and writes them to targetDir.
-func InstallOpencode(srcDir, targetDir, model string, disabled []string, dryRun bool) (int, error) {
+// InstallOpencode transforms agent files for opencode and writes them to
+// targetDir. Returns the filenames installed (including in dryRun mode), so
+// callers can diff against a manifest to detect stale files from prior runs.
+func InstallOpencode(srcDir, targetDir, model string, disabled []string, dryRun bool) ([]string, error) {
 	entries, err := os.ReadDir(srcDir)
 	if err != nil {
-		return 0, err
+		return nil, err
 	}
-	count := 0
+	var installed []string
 	for _, entry := range entries {
 		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".md") {
 			continue
@@ -114,7 +118,7 @@ func InstallOpencode(srcDir, targetDir, model string, disabled []string, dryRun 
 		}
 		content, err := os.ReadFile(filepath.Join(srcDir, name))
 		if err != nil {
-			return count, err
+			return installed, err
 		}
 		transformed, err := transformForOpencode(string(content), model, false)
 		if err != nil {
@@ -124,31 +128,34 @@ func InstallOpencode(srcDir, targetDir, model string, disabled []string, dryRun 
 		dest := filepath.Join(targetDir, name)
 		if dryRun {
 			ui.DryRun(fmt.Sprintf("transform + write %s", dest))
-			count++
+			installed = append(installed, name)
 			continue
 		}
 		if err := os.MkdirAll(targetDir, 0755); err != nil {
-			return count, err
+			return installed, err
 		}
 		if err := os.WriteFile(dest, []byte(transformed), 0644); err != nil {
-			return count, err
+			return installed, err
 		}
 		ui.Added(name)
-		count++
+		installed = append(installed, name)
 	}
-	return count, nil
+	return installed, nil
 }
 
-// InstallOpencodeExclusive copies opencode-exclusive agents (agents/opencode/) with model-only substitution.
-func InstallOpencodeExclusive(srcDir, targetDir, model string, dryRun bool) (int, error) {
+// InstallOpencodeExclusive copies opencode-exclusive agents
+// (agents/opencode/) with model-only substitution. Returns the filenames
+// installed (including in dryRun mode), so callers can diff against a
+// manifest to detect stale files from prior runs.
+func InstallOpencodeExclusive(srcDir, targetDir, model string, dryRun bool) ([]string, error) {
 	entries, err := os.ReadDir(srcDir)
 	if os.IsNotExist(err) {
-		return 0, nil
+		return nil, nil
 	}
 	if err != nil {
-		return 0, err
+		return nil, err
 	}
-	count := 0
+	var installed []string
 	for _, entry := range entries {
 		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".md") {
 			continue
@@ -156,7 +163,7 @@ func InstallOpencodeExclusive(srcDir, targetDir, model string, dryRun bool) (int
 		name := entry.Name()
 		content, err := os.ReadFile(filepath.Join(srcDir, name))
 		if err != nil {
-			return count, err
+			return installed, err
 		}
 		transformed, err := transformForOpencode(string(content), model, true)
 		if err != nil {
@@ -166,19 +173,19 @@ func InstallOpencodeExclusive(srcDir, targetDir, model string, dryRun bool) (int
 		dest := filepath.Join(targetDir, name)
 		if dryRun {
 			ui.DryRun(fmt.Sprintf("write %s (opencode-exclusive)", dest))
-			count++
+			installed = append(installed, name)
 			continue
 		}
 		if err := os.MkdirAll(targetDir, 0755); err != nil {
-			return count, err
+			return installed, err
 		}
 		if err := os.WriteFile(dest, []byte(transformed), 0644); err != nil {
-			return count, err
+			return installed, err
 		}
 		ui.Added(fmt.Sprintf("%s (opencode-exclusive)", name))
-		count++
+		installed = append(installed, name)
 	}
-	return count, nil
+	return installed, nil
 }
 
 // transformForOpencode ports transform_agent.py to Go.

--- a/cli/internal/agents/installer_test.go
+++ b/cli/internal/agents/installer_test.go
@@ -3,6 +3,8 @@ package agents
 import (
 	"os"
 	"path/filepath"
+	"reflect"
+	"sort"
 	"strings"
 	"testing"
 )
@@ -161,6 +163,230 @@ mode: subagent
 			}
 			if got != tt.want {
 				t.Errorf("transformForOpencode() =\n%s\nwant:\n%s", got, tt.want)
+			}
+		})
+	}
+}
+
+func writeAgentFiles(t *testing.T, dir string, files map[string]string) {
+	t.Helper()
+	for name, content := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0644); err != nil {
+			t.Fatalf("WriteFile(%s) error = %v", name, err)
+		}
+	}
+}
+
+func TestInstallClaude(t *testing.T) {
+	agentContent := `---
+name: sample-agent
+description: "A sample agent"
+model: sonnet
+---
+
+# Sample Agent
+`
+
+	tests := map[string]struct {
+		files         map[string]string
+		model         string
+		disabled      []string
+		dryRun        bool
+		wantInstalled []string
+	}{
+		"installs all md files except README": {
+			files: map[string]string{
+				"agent-a.md": agentContent,
+				"agent-b.md": agentContent,
+				"README.md":  "# readme",
+				"notes.txt":  "not an agent",
+			},
+			wantInstalled: []string{"agent-a.md", "agent-b.md"},
+		},
+		"skips disabled agents and excludes from installed list": {
+			files: map[string]string{
+				"agent-a.md": agentContent,
+				"agent-b.md": agentContent,
+			},
+			disabled:      []string{"agent-b"},
+			wantInstalled: []string{"agent-a.md"},
+		},
+		"dry run returns would-be list without writing files": {
+			files: map[string]string{
+				"agent-a.md": agentContent,
+			},
+			dryRun:        true,
+			wantInstalled: []string{"agent-a.md"},
+		},
+		"applies model override to model line": {
+			files: map[string]string{
+				"agent-a.md": agentContent,
+			},
+			model:         "haiku",
+			wantInstalled: []string{"agent-a.md"},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			srcDir := t.TempDir()
+			targetDir := filepath.Join(t.TempDir(), "target")
+			writeAgentFiles(t, srcDir, tt.files)
+
+			got, err := InstallClaude(srcDir, targetDir, tt.model, tt.disabled, tt.dryRun)
+			if err != nil {
+				t.Fatalf("InstallClaude() error = %v", err)
+			}
+
+			sort.Strings(got)
+			sort.Strings(tt.wantInstalled)
+			if !reflect.DeepEqual(got, tt.wantInstalled) {
+				t.Errorf("InstallClaude() = %v, want %v", got, tt.wantInstalled)
+			}
+
+			if tt.dryRun {
+				if _, err := os.Stat(targetDir); !os.IsNotExist(err) {
+					t.Errorf("dry run should not create targetDir")
+				}
+				return
+			}
+
+			if tt.model != "" {
+				data, err := os.ReadFile(filepath.Join(targetDir, "agent-a.md"))
+				if err != nil {
+					t.Fatalf("ReadFile(agent-a.md) error = %v", err)
+				}
+				if !strings.Contains(string(data), "model: anthropic/claude-haiku-4-5-20251001") {
+					t.Errorf("installed file does not contain overridden model line:\n%s", data)
+				}
+			}
+		})
+	}
+}
+
+func TestInstallOpencode(t *testing.T) {
+	agentContent := `---
+name: sample-agent
+description: "A sample agent"
+model: sonnet
+tools: Read, Edit
+---
+
+# Sample Agent
+`
+
+	tests := map[string]struct {
+		files         map[string]string
+		disabled      []string
+		dryRun        bool
+		wantInstalled []string
+	}{
+		"installs all md files except README": {
+			files: map[string]string{
+				"agent-a.md": agentContent,
+				"agent-b.md": agentContent,
+				"README.md":  "# readme",
+			},
+			wantInstalled: []string{"agent-a.md", "agent-b.md"},
+		},
+		"skips disabled agents and excludes from installed list": {
+			files: map[string]string{
+				"agent-a.md": agentContent,
+				"agent-b.md": agentContent,
+			},
+			disabled:      []string{"agent-b"},
+			wantInstalled: []string{"agent-a.md"},
+		},
+		"dry run returns would-be list without writing files": {
+			files: map[string]string{
+				"agent-a.md": agentContent,
+			},
+			dryRun:        true,
+			wantInstalled: []string{"agent-a.md"},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			srcDir := t.TempDir()
+			targetDir := filepath.Join(t.TempDir(), "target")
+			writeAgentFiles(t, srcDir, tt.files)
+
+			got, err := InstallOpencode(srcDir, targetDir, "", tt.disabled, tt.dryRun)
+			if err != nil {
+				t.Fatalf("InstallOpencode() error = %v", err)
+			}
+
+			sort.Strings(got)
+			sort.Strings(tt.wantInstalled)
+			if !reflect.DeepEqual(got, tt.wantInstalled) {
+				t.Errorf("InstallOpencode() = %v, want %v", got, tt.wantInstalled)
+			}
+
+			if tt.dryRun {
+				if _, err := os.Stat(targetDir); !os.IsNotExist(err) {
+					t.Errorf("dry run should not create targetDir")
+				}
+			}
+		})
+	}
+}
+
+func TestInstallOpencodeExclusive(t *testing.T) {
+	exclusiveContent := `---
+name: opencode-only-agent
+description: "An opencode-exclusive agent"
+model: sonnet
+---
+
+# Opencode Only Agent
+`
+
+	tests := map[string]struct {
+		missingSrcDir bool
+		files         map[string]string
+		dryRun        bool
+		wantInstalled []string
+	}{
+		"missing srcDir returns nil installed and nil error": {
+			missingSrcDir: true,
+		},
+		"installs all md files in srcDir": {
+			files: map[string]string{
+				"opencode-agent-a.md": exclusiveContent,
+				"opencode-agent-b.md": exclusiveContent,
+			},
+			wantInstalled: []string{"opencode-agent-a.md", "opencode-agent-b.md"},
+		},
+		"dry run returns would-be list without writing files": {
+			files: map[string]string{
+				"opencode-agent-a.md": exclusiveContent,
+			},
+			dryRun:        true,
+			wantInstalled: []string{"opencode-agent-a.md"},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			var srcDir string
+			if tt.missingSrcDir {
+				srcDir = filepath.Join(t.TempDir(), "does-not-exist")
+			} else {
+				srcDir = t.TempDir()
+				writeAgentFiles(t, srcDir, tt.files)
+			}
+			targetDir := filepath.Join(t.TempDir(), "target")
+
+			got, err := InstallOpencodeExclusive(srcDir, targetDir, "", tt.dryRun)
+			if err != nil {
+				t.Fatalf("InstallOpencodeExclusive() error = %v", err)
+			}
+
+			sort.Strings(got)
+			sort.Strings(tt.wantInstalled)
+			if !reflect.DeepEqual(got, tt.wantInstalled) {
+				t.Errorf("InstallOpencodeExclusive() = %v, want %v", got, tt.wantInstalled)
 			}
 		})
 	}

--- a/cli/internal/hooks/installer.go
+++ b/cli/internal/hooks/installer.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"devexp/internal/ui"
 )
@@ -54,6 +55,8 @@ func InstallClaude(registry Registry, repoDir, settingsPath string, disabled []s
 	if hooksRaw, ok := raw["hooks"]; ok {
 		json.Unmarshal(hooksRaw, &hooksMap) //nolint:errcheck
 	}
+
+	pruned := pruneStaleHooks(hooksMap, repoDir, dryRun)
 
 	isDisabled := func(name string) bool {
 		for _, d := range disabled {
@@ -107,7 +110,10 @@ func InstallClaude(registry Registry, repoDir, settingsPath string, disabled []s
 		fmt.Printf("  \033[0;32m+\033[0m %s: %s\n", cc.Event, filepath.Base(cc.Script))
 	}
 
-	if !changed || dryRun {
+	if dryRun {
+		return nil
+	}
+	if !changed && !pruned {
 		return nil
 	}
 
@@ -129,4 +135,52 @@ func InstallClaude(registry Registry, repoDir, settingsPath string, disabled []s
 	}
 	fmt.Printf("  Saved: %s\n", settingsPath)
 	return nil
+}
+
+// pruneStaleHooks removes registered hook commands that live under repoDir
+// (devexp-managed) but whose backing script no longer exists on disk — i.e.
+// the hook was removed from this version's registry. User-authored hooks
+// pointing elsewhere are left untouched. Returns whether anything was pruned.
+func pruneStaleHooks(hooksMap map[string][]hookEntry, repoDir string, dryRun bool) bool {
+	pruned := false
+	for event, entries := range hooksMap {
+		var kept []hookEntry
+		for _, e := range entries {
+			var keptCmds []hookCmd
+			for _, h := range e.Hooks {
+				if isStaleDevexpHook(h.Command, repoDir) {
+					if dryRun {
+						ui.DryRun(fmt.Sprintf("remove %s hook: %s (script no longer exists)", event, filepath.Base(h.Command)))
+					} else {
+						ui.Removed(fmt.Sprintf("%s: %s (script no longer exists)", event, filepath.Base(h.Command)))
+					}
+					pruned = true
+					continue
+				}
+				keptCmds = append(keptCmds, h)
+			}
+			if len(keptCmds) == 0 {
+				continue
+			}
+			e.Hooks = keptCmds
+			kept = append(kept, e)
+		}
+		if len(kept) == 0 {
+			delete(hooksMap, event)
+		} else {
+			hooksMap[event] = kept
+		}
+	}
+	return pruned
+}
+
+// isStaleDevexpHook reports whether cmd is a devexp-managed command (lives
+// under repoDir) whose script no longer exists on disk.
+func isStaleDevexpHook(cmd, repoDir string) bool {
+	rel, err := filepath.Rel(repoDir, cmd)
+	if err != nil || strings.HasPrefix(rel, "..") || rel == "." {
+		return false
+	}
+	_, statErr := os.Stat(cmd)
+	return os.IsNotExist(statErr)
 }

--- a/cli/internal/hooks/installer_test.go
+++ b/cli/internal/hooks/installer_test.go
@@ -1,0 +1,324 @@
+package hooks
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+type hooksMapT = map[string][]hookEntry
+
+func createScript(t *testing.T, repoDir, relPath string) string {
+	t.Helper()
+	abs := filepath.Join(repoDir, relPath)
+	if err := os.MkdirAll(filepath.Dir(abs), 0755); err != nil {
+		t.Fatalf("MkdirAll error = %v", err)
+	}
+	if err := os.WriteFile(abs, []byte("#!/bin/sh\n"), 0755); err != nil {
+		t.Fatalf("WriteFile error = %v", err)
+	}
+	return abs
+}
+
+func writeSettingsHooks(t *testing.T, settingsPath string, hooks hooksMapT) {
+	t.Helper()
+	hooksBytes, err := json.Marshal(hooks)
+	if err != nil {
+		t.Fatalf("Marshal hooks error = %v", err)
+	}
+	raw := map[string]json.RawMessage{"hooks": hooksBytes}
+	data, err := json.MarshalIndent(raw, "", "  ")
+	if err != nil {
+		t.Fatalf("MarshalIndent error = %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0755); err != nil {
+		t.Fatalf("MkdirAll error = %v", err)
+	}
+	if err := os.WriteFile(settingsPath, data, 0644); err != nil {
+		t.Fatalf("WriteFile error = %v", err)
+	}
+}
+
+func readHooks(t *testing.T, settingsPath string) hooksMapT {
+	t.Helper()
+	data, err := os.ReadFile(settingsPath)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		t.Fatalf("ReadFile(%s) error = %v", settingsPath, err)
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("Unmarshal settings error = %v", err)
+	}
+	var hooks hooksMapT
+	if hooksRaw, ok := raw["hooks"]; ok {
+		if err := json.Unmarshal(hooksRaw, &hooks); err != nil {
+			t.Fatalf("Unmarshal hooks error = %v", err)
+		}
+	}
+	return hooks
+}
+
+func TestIsStaleDevexpHook(t *testing.T) {
+	repoDir := t.TempDir()
+	existingScript := createScript(t, repoDir, "hooks/claude-code/exists.sh")
+	missingScript := filepath.Join(repoDir, "hooks", "claude-code", "missing.sh")
+
+	outsideDir := t.TempDir()
+	outsideExisting := filepath.Join(outsideDir, "user-hook.sh")
+	if err := os.WriteFile(outsideExisting, []byte("#!/bin/sh\n"), 0755); err != nil {
+		t.Fatalf("WriteFile error = %v", err)
+	}
+	outsideMissing := filepath.Join(outsideDir, "missing-user-hook.sh")
+
+	tests := map[string]struct {
+		cmd  string
+		want bool
+	}{
+		"existing script under repoDir is not stale": {
+			cmd:  existingScript,
+			want: false,
+		},
+		"missing script under repoDir is stale": {
+			cmd:  missingScript,
+			want: true,
+		},
+		"existing script outside repoDir is not stale": {
+			cmd:  outsideExisting,
+			want: false,
+		},
+		"missing script outside repoDir is not stale (user hook)": {
+			cmd:  outsideMissing,
+			want: false,
+		},
+		"cmd equal to repoDir itself is not stale": {
+			cmd:  repoDir,
+			want: false,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := isStaleDevexpHook(tt.cmd, repoDir)
+			if got != tt.want {
+				t.Errorf("isStaleDevexpHook(%q, %q) = %v, want %v", tt.cmd, repoDir, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPruneStaleHooks(t *testing.T) {
+	repoDir := t.TempDir()
+	existingScript := createScript(t, repoDir, "hooks/claude-code/exists.sh")
+	missingScript := filepath.Join(repoDir, "hooks", "claude-code", "missing.sh")
+	userScript := filepath.Join(t.TempDir(), "user-hook.sh")
+
+	tests := map[string]struct {
+		hooksMap   hooksMapT
+		wantHooks  hooksMapT
+		wantPruned bool
+	}{
+		"prunes individual stale hook but keeps others in the same entry": {
+			hooksMap: hooksMapT{
+				"PreToolUse": {
+					{Matcher: "Bash", Hooks: []hookCmd{
+						{Type: "command", Command: existingScript},
+						{Type: "command", Command: missingScript},
+					}},
+				},
+			},
+			wantHooks: hooksMapT{
+				"PreToolUse": {
+					{Matcher: "Bash", Hooks: []hookCmd{
+						{Type: "command", Command: existingScript},
+					}},
+				},
+			},
+			wantPruned: true,
+		},
+		"removes the event key entirely when all its hooks are stale": {
+			hooksMap: hooksMapT{
+				"PreToolUse": {
+					{Matcher: "Bash", Hooks: []hookCmd{
+						{Type: "command", Command: missingScript},
+					}},
+				},
+			},
+			wantHooks:  hooksMapT{},
+			wantPruned: true,
+		},
+		"leaves user hooks and valid devexp hooks untouched": {
+			hooksMap: hooksMapT{
+				"PreToolUse": {
+					{Matcher: "Bash", Hooks: []hookCmd{
+						{Type: "command", Command: existingScript},
+						{Type: "command", Command: userScript},
+					}},
+				},
+			},
+			wantHooks: hooksMapT{
+				"PreToolUse": {
+					{Matcher: "Bash", Hooks: []hookCmd{
+						{Type: "command", Command: existingScript},
+						{Type: "command", Command: userScript},
+					}},
+				},
+			},
+			wantPruned: false,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := pruneStaleHooks(tt.hooksMap, repoDir, false)
+			if got != tt.wantPruned {
+				t.Errorf("pruneStaleHooks() pruned = %v, want %v", got, tt.wantPruned)
+			}
+			if !reflect.DeepEqual(tt.hooksMap, tt.wantHooks) {
+				t.Errorf("pruneStaleHooks() hooksMap = %+v, want %+v", tt.hooksMap, tt.wantHooks)
+			}
+		})
+	}
+}
+
+func TestInstallClaude(t *testing.T) {
+	tests := map[string]struct {
+		setup  func(t *testing.T, repoDir, settingsPath string) (Registry, []string)
+		dryRun bool
+		check  func(t *testing.T, repoDir, settingsPath string)
+	}{
+		"adds a new hook not yet registered": {
+			setup: func(t *testing.T, repoDir, settingsPath string) (Registry, []string) {
+				createScript(t, repoDir, "hooks/claude-code/foo.sh")
+				return Registry{{
+					Name: "foo", Enabled: true,
+					ClaudeCode: HookCC{Event: "PreToolUse", Matcher: "Bash", Script: "hooks/claude-code/foo.sh"},
+				}}, nil
+			},
+			check: func(t *testing.T, repoDir, settingsPath string) {
+				got := readHooks(t, settingsPath)
+				want := hooksMapT{
+					"PreToolUse": {
+						{Matcher: "Bash", Hooks: []hookCmd{
+							{Type: "command", Command: filepath.Join(repoDir, "hooks/claude-code/foo.sh")},
+						}},
+					},
+				}
+				if !reflect.DeepEqual(got, want) {
+					t.Errorf("hooks = %+v, want %+v", got, want)
+				}
+			},
+		},
+		"skips a hook already registered": {
+			setup: func(t *testing.T, repoDir, settingsPath string) (Registry, []string) {
+				scriptAbs := createScript(t, repoDir, "hooks/claude-code/foo.sh")
+				writeSettingsHooks(t, settingsPath, hooksMapT{
+					"PreToolUse": {
+						{Matcher: "Bash", Hooks: []hookCmd{
+							{Type: "command", Command: scriptAbs},
+						}},
+					},
+				})
+				return Registry{{
+					Name: "foo", Enabled: true,
+					ClaudeCode: HookCC{Event: "PreToolUse", Matcher: "Bash", Script: "hooks/claude-code/foo.sh"},
+				}}, nil
+			},
+			check: func(t *testing.T, repoDir, settingsPath string) {
+				got := readHooks(t, settingsPath)
+				want := hooksMapT{
+					"PreToolUse": {
+						{Matcher: "Bash", Hooks: []hookCmd{
+							{Type: "command", Command: filepath.Join(repoDir, "hooks/claude-code/foo.sh")},
+						}},
+					},
+				}
+				if !reflect.DeepEqual(got, want) {
+					t.Errorf("hooks = %+v, want %+v", got, want)
+				}
+			},
+		},
+		"skips a disabled hook, leaving settings.json unwritten": {
+			setup: func(t *testing.T, repoDir, settingsPath string) (Registry, []string) {
+				createScript(t, repoDir, "hooks/claude-code/foo.sh")
+				return Registry{{
+					Name: "foo", Enabled: true,
+					ClaudeCode: HookCC{Event: "PreToolUse", Matcher: "Bash", Script: "hooks/claude-code/foo.sh"},
+				}}, []string{"foo"}
+			},
+			check: func(t *testing.T, repoDir, settingsPath string) {
+				if got := readHooks(t, settingsPath); got != nil {
+					t.Errorf("hooks = %+v, want settings.json to not exist", got)
+				}
+			},
+		},
+		"prune-only run rewrites settings.json to drop a hook whose script no longer exists": {
+			setup: func(t *testing.T, repoDir, settingsPath string) (Registry, []string) {
+				writeSettingsHooks(t, settingsPath, hooksMapT{
+					"PreToolUse": {
+						{Matcher: "Bash", Hooks: []hookCmd{
+							{Type: "command", Command: filepath.Join(repoDir, "hooks/claude-code/removed.sh")},
+						}},
+					},
+				})
+				return Registry{}, nil
+			},
+			check: func(t *testing.T, repoDir, settingsPath string) {
+				got := readHooks(t, settingsPath)
+				want := hooksMapT{}
+				if !reflect.DeepEqual(got, want) {
+					t.Errorf("hooks = %+v, want %+v", got, want)
+				}
+			},
+		},
+		"dry run reports additions and prunes without writing settings.json": {
+			setup: func(t *testing.T, repoDir, settingsPath string) (Registry, []string) {
+				createScript(t, repoDir, "hooks/claude-code/foo.sh")
+				writeSettingsHooks(t, settingsPath, hooksMapT{
+					"PreToolUse": {
+						{Matcher: "Bash", Hooks: []hookCmd{
+							{Type: "command", Command: filepath.Join(repoDir, "hooks/claude-code/removed.sh")},
+						}},
+					},
+				})
+				return Registry{{
+					Name: "foo", Enabled: true,
+					ClaudeCode: HookCC{Event: "PreToolUse", Matcher: "Bash", Script: "hooks/claude-code/foo.sh"},
+				}}, nil
+			},
+			dryRun: true,
+			check: func(t *testing.T, repoDir, settingsPath string) {
+				got := readHooks(t, settingsPath)
+				want := hooksMapT{
+					"PreToolUse": {
+						{Matcher: "Bash", Hooks: []hookCmd{
+							{Type: "command", Command: filepath.Join(repoDir, "hooks/claude-code/removed.sh")},
+						}},
+					},
+				}
+				if !reflect.DeepEqual(got, want) {
+					t.Errorf("hooks = %+v, want %+v (dry run must not write)", got, want)
+				}
+			},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			repoDir := t.TempDir()
+			settingsPath := filepath.Join(t.TempDir(), "settings.json")
+
+			registry, disabled := tt.setup(t, repoDir, settingsPath)
+
+			if err := InstallClaude(registry, repoDir, settingsPath, disabled, tt.dryRun); err != nil {
+				t.Fatalf("InstallClaude() error = %v", err)
+			}
+
+			tt.check(t, repoDir, settingsPath)
+		})
+	}
+}

--- a/cli/internal/manifest/manifest.go
+++ b/cli/internal/manifest/manifest.go
@@ -1,0 +1,69 @@
+// Package manifest tracks which agent and skill files devexp installed on a
+// prior run, so a later run can detect and remove files that are no longer
+// shipped by the toolkit (stale files left over from an older version).
+package manifest
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+)
+
+// Manifest records the filenames/dirnames devexp installed for one target
+// (Claude or opencode) on the most recent run of each category. Entries are
+// the same names returned by the agents/skills installers (e.g.
+// "code-reviewer.md" for an agent, "graphify" for a skill directory).
+type Manifest struct {
+	Agents []string `json:"agents"`
+	Skills []string `json:"skills"`
+}
+
+// Load reads a manifest from path. A missing file is not an error — it
+// returns an empty Manifest, which is the expected state on a first install
+// or when upgrading from a devexp version that predates manifests. A
+// malformed file is tolerated the same way, so a corrupt cache file never
+// blocks install.
+func Load(path string) (*Manifest, error) {
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return &Manifest{}, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var m Manifest
+	if err := json.Unmarshal(data, &m); err != nil {
+		return &Manifest{}, nil
+	}
+	return &m, nil
+}
+
+// Save writes m to path as indented JSON, creating parent directories as
+// needed.
+func Save(path string, m *Manifest) error {
+	data, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0644)
+}
+
+// Stale returns entries present in old but not in newList — i.e. files that
+// were installed previously but are not part of this run's install set, and
+// should be removed from the target directory.
+func Stale(old, newList []string) []string {
+	keep := make(map[string]bool, len(newList))
+	for _, n := range newList {
+		keep[n] = true
+	}
+	var stale []string
+	for _, n := range old {
+		if !keep[n] {
+			stale = append(stale, n)
+		}
+	}
+	return stale
+}

--- a/cli/internal/manifest/manifest_test.go
+++ b/cli/internal/manifest/manifest_test.go
@@ -1,0 +1,138 @@
+package manifest
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestLoad(t *testing.T) {
+	tests := map[string]struct {
+		setup func(t *testing.T, dir string) string // returns manifest path
+		want  *Manifest
+	}{
+		"missing file returns empty manifest": {
+			setup: func(t *testing.T, dir string) string {
+				return filepath.Join(dir, "missing.json")
+			},
+			want: &Manifest{},
+		},
+		"valid JSON round-trips agents and skills": {
+			setup: func(t *testing.T, dir string) string {
+				path := filepath.Join(dir, "manifest.json")
+				data := `{"agents":["a.md","b.md"],"skills":["graphify"]}`
+				if err := os.WriteFile(path, []byte(data), 0644); err != nil {
+					t.Fatalf("WriteFile: %v", err)
+				}
+				return path
+			},
+			want: &Manifest{Agents: []string{"a.md", "b.md"}, Skills: []string{"graphify"}},
+		},
+		"malformed JSON returns empty manifest": {
+			setup: func(t *testing.T, dir string) string {
+				path := filepath.Join(dir, "bad.json")
+				if err := os.WriteFile(path, []byte("not json"), 0644); err != nil {
+					t.Fatalf("WriteFile: %v", err)
+				}
+				return path
+			},
+			want: &Manifest{},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := tt.setup(t, dir)
+
+			got, err := Load(path)
+			if err != nil {
+				t.Fatalf("Load() error = %v", err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Load() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSave(t *testing.T) {
+	tests := map[string]struct {
+		manifest *Manifest
+	}{
+		"writes and round-trips agents and skills": {
+			manifest: &Manifest{Agents: []string{"a.md", "b.md"}, Skills: []string{"graphify", "deliver"}},
+		},
+		"writes empty manifest": {
+			manifest: &Manifest{},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "nested", "manifest.json")
+
+			if err := Save(path, tt.manifest); err != nil {
+				t.Fatalf("Save() error = %v", err)
+			}
+
+			got, err := Load(path)
+			if err != nil {
+				t.Fatalf("Load() error = %v", err)
+			}
+			if !reflect.DeepEqual(got, tt.manifest) {
+				t.Errorf("round-trip = %+v, want %+v", got, tt.manifest)
+			}
+		})
+	}
+}
+
+func TestStale(t *testing.T) {
+	tests := map[string]struct {
+		old     []string
+		newList []string
+		want    []string
+	}{
+		"entries in old not in new are returned": {
+			old:     []string{"a.md", "b.md", "c.md"},
+			newList: []string{"a.md"},
+			want:    []string{"b.md", "c.md"},
+		},
+		"entries in both old and new are not returned": {
+			old:     []string{"a.md", "b.md"},
+			newList: []string{"a.md", "b.md"},
+			want:    nil,
+		},
+		"new entries not in old do not appear in result": {
+			old:     []string{"a.md"},
+			newList: []string{"a.md", "b.md"},
+			want:    nil,
+		},
+		"empty old returns nil": {
+			old:     nil,
+			newList: []string{"a.md"},
+			want:    nil,
+		},
+		"empty new returns all of old": {
+			old:     []string{"a.md", "b.md"},
+			newList: nil,
+			want:    []string{"a.md", "b.md"},
+		},
+		"nil inputs handled without panic": {
+			old:     nil,
+			newList: nil,
+			want:    nil,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := Stale(tt.old, tt.newList)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Stale() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/cli/internal/skills/installer.go
+++ b/cli/internal/skills/installer.go
@@ -10,13 +10,15 @@ import (
 )
 
 // InstallClaude copies each skill directory (SKILL.md plus any supplementary
-// files, e.g. references/) into ~/.claude/skills/<name>/
-func InstallClaude(srcDir, targetDir string, disabled []string, dryRun bool) (int, error) {
+// files, e.g. references/) into ~/.claude/skills/<name>/. Returns the
+// installed skill dirnames (including in dryRun mode), so callers can diff
+// against a manifest to detect stale skills from prior runs.
+func InstallClaude(srcDir, targetDir string, disabled []string, dryRun bool) ([]string, error) {
 	entries, err := os.ReadDir(srcDir)
 	if err != nil {
-		return 0, err
+		return nil, err
 	}
-	count := 0
+	var installed []string
 	for _, entry := range entries {
 		if !entry.IsDir() {
 			continue
@@ -33,20 +35,20 @@ func InstallClaude(srcDir, targetDir string, disabled []string, dryRun bool) (in
 		destDir := filepath.Join(targetDir, name)
 		if dryRun {
 			ui.DryRun(fmt.Sprintf("write %s/", destDir))
-			count++
+			installed = append(installed, name)
 			continue
 		}
-		if err := copyDir(skillDir, destDir); err != nil {
-			return count, err
+		if err := CopyDir(skillDir, destDir); err != nil {
+			return installed, err
 		}
 		ui.Added(fmt.Sprintf("%s/SKILL.md", name))
-		count++
+		installed = append(installed, name)
 	}
-	return count, nil
+	return installed, nil
 }
 
-// copyDir recursively copies all files and subdirectories from src to dst.
-func copyDir(src, dst string) error {
+// CopyDir recursively copies all files and subdirectories from src to dst.
+func CopyDir(src, dst string) error {
 	return filepath.WalkDir(src, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -68,13 +70,16 @@ func copyDir(src, dst string) error {
 }
 
 // InstallOpencode copies skills as <name>.md into ~/.config/opencode/commands/
-// (strips the `name:` frontmatter line, which opencode derives from the filename)
-func InstallOpencode(srcDir, targetDir string, disabled []string, dryRun bool) (int, error) {
+// (strips the `name:` frontmatter line, which opencode derives from the
+// filename). Returns the installed skill dirnames, bare (no .md suffix), for
+// consistency with InstallClaude's manifest entries — callers append .md when
+// removing stale opencode skill files. Includes dryRun mode.
+func InstallOpencode(srcDir, targetDir string, disabled []string, dryRun bool) ([]string, error) {
 	entries, err := os.ReadDir(srcDir)
 	if err != nil {
-		return 0, err
+		return nil, err
 	}
-	count := 0
+	var installed []string
 	for _, entry := range entries {
 		if !entry.IsDir() {
 			continue
@@ -91,12 +96,12 @@ func InstallOpencode(srcDir, targetDir string, disabled []string, dryRun bool) (
 		dest := filepath.Join(targetDir, name+".md")
 		if dryRun {
 			ui.DryRun(fmt.Sprintf("write %s", dest))
-			count++
+			installed = append(installed, name)
 			continue
 		}
 		content, err := os.ReadFile(skillFile)
 		if err != nil {
-			return count, err
+			return installed, err
 		}
 		// Strip `name:` line — opencode derives name from filename
 		var lines []string
@@ -106,15 +111,15 @@ func InstallOpencode(srcDir, targetDir string, disabled []string, dryRun bool) (
 			}
 		}
 		if err := os.MkdirAll(targetDir, 0755); err != nil {
-			return count, err
+			return installed, err
 		}
 		if err := os.WriteFile(dest, []byte(strings.Join(lines, "\n")), 0644); err != nil {
-			return count, err
+			return installed, err
 		}
 		ui.Added(fmt.Sprintf("%s.md", name))
-		count++
+		installed = append(installed, name)
 	}
-	return count, nil
+	return installed, nil
 }
 
 func isDisabled(name string, disabled []string) bool {

--- a/cli/internal/skills/installer_test.go
+++ b/cli/internal/skills/installer_test.go
@@ -1,0 +1,183 @@
+package skills
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+)
+
+const sampleSkillMD = `---
+name: alpha
+description: "A sample skill"
+---
+
+# Alpha Skill
+`
+
+// writeSkillDir creates srcDir/name/ and writes each file (keyed by relative
+// path within the skill dir) with its content.
+func writeSkillDir(t *testing.T, srcDir, name string, files map[string]string) {
+	t.Helper()
+	skillDir := filepath.Join(srcDir, name)
+	for rel, content := range files {
+		path := filepath.Join(skillDir, rel)
+		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+			t.Fatalf("MkdirAll(%s) error = %v", filepath.Dir(path), err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+			t.Fatalf("WriteFile(%s) error = %v", path, err)
+		}
+	}
+}
+
+func TestInstallClaude(t *testing.T) {
+	tests := map[string]struct {
+		skills        map[string]map[string]string // skill dirname -> relative file -> content
+		disabled      []string
+		dryRun        bool
+		wantInstalled []string
+		wantNestedRef bool
+	}{
+		"installs skill dirs containing SKILL.md, skips dirs without it": {
+			skills: map[string]map[string]string{
+				"alpha": {
+					"SKILL.md":            sampleSkillMD,
+					"references/notes.md": "# Notes\n",
+				},
+				"beta": {
+					"SKILL.md": sampleSkillMD,
+				},
+				"not-a-skill": {
+					"notes.txt": "no SKILL.md here",
+				},
+			},
+			wantInstalled: []string{"alpha", "beta"},
+			wantNestedRef: true,
+		},
+		"skips disabled skills and excludes from installed list": {
+			skills: map[string]map[string]string{
+				"alpha": {"SKILL.md": sampleSkillMD},
+				"beta":  {"SKILL.md": sampleSkillMD},
+			},
+			disabled:      []string{"beta"},
+			wantInstalled: []string{"alpha"},
+		},
+		"dry run returns would-be list without writing files": {
+			skills: map[string]map[string]string{
+				"alpha": {"SKILL.md": sampleSkillMD},
+			},
+			dryRun:        true,
+			wantInstalled: []string{"alpha"},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			srcDir := t.TempDir()
+			targetDir := filepath.Join(t.TempDir(), "target")
+			for skillName, files := range tt.skills {
+				writeSkillDir(t, srcDir, skillName, files)
+			}
+
+			got, err := InstallClaude(srcDir, targetDir, tt.disabled, tt.dryRun)
+			if err != nil {
+				t.Fatalf("InstallClaude() error = %v", err)
+			}
+
+			sort.Strings(got)
+			sort.Strings(tt.wantInstalled)
+			if !reflect.DeepEqual(got, tt.wantInstalled) {
+				t.Errorf("InstallClaude() = %v, want %v", got, tt.wantInstalled)
+			}
+
+			if tt.dryRun {
+				if _, err := os.Stat(targetDir); !os.IsNotExist(err) {
+					t.Errorf("dry run should not create targetDir")
+				}
+				return
+			}
+
+			if tt.wantNestedRef {
+				data, err := os.ReadFile(filepath.Join(targetDir, "alpha", "references", "notes.md"))
+				if err != nil {
+					t.Fatalf("nested reference file not copied: %v", err)
+				}
+				if string(data) != "# Notes\n" {
+					t.Errorf("nested reference file content = %q, want %q", data, "# Notes\n")
+				}
+			}
+		})
+	}
+}
+
+func TestInstallOpencode(t *testing.T) {
+	tests := map[string]struct {
+		skills        map[string]map[string]string
+		disabled      []string
+		dryRun        bool
+		wantInstalled []string
+	}{
+		"writes <name>.md stripping name: frontmatter line": {
+			skills: map[string]map[string]string{
+				"alpha": {"SKILL.md": sampleSkillMD},
+			},
+			wantInstalled: []string{"alpha"},
+		},
+		"skips disabled skills and excludes from installed list": {
+			skills: map[string]map[string]string{
+				"alpha": {"SKILL.md": sampleSkillMD},
+				"beta":  {"SKILL.md": sampleSkillMD},
+			},
+			disabled:      []string{"beta"},
+			wantInstalled: []string{"alpha"},
+		},
+		"dry run returns would-be list without writing files": {
+			skills: map[string]map[string]string{
+				"alpha": {"SKILL.md": sampleSkillMD},
+			},
+			dryRun:        true,
+			wantInstalled: []string{"alpha"},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			srcDir := t.TempDir()
+			targetDir := filepath.Join(t.TempDir(), "target")
+			for skillName, files := range tt.skills {
+				writeSkillDir(t, srcDir, skillName, files)
+			}
+
+			got, err := InstallOpencode(srcDir, targetDir, tt.disabled, tt.dryRun)
+			if err != nil {
+				t.Fatalf("InstallOpencode() error = %v", err)
+			}
+
+			sort.Strings(got)
+			sort.Strings(tt.wantInstalled)
+			if !reflect.DeepEqual(got, tt.wantInstalled) {
+				t.Errorf("InstallOpencode() = %v, want %v", got, tt.wantInstalled)
+			}
+
+			if tt.dryRun {
+				if _, err := os.Stat(targetDir); !os.IsNotExist(err) {
+					t.Errorf("dry run should not create targetDir")
+				}
+				return
+			}
+
+			if _, ok := tt.skills["alpha"]; ok {
+				data, err := os.ReadFile(filepath.Join(targetDir, "alpha.md"))
+				if err != nil {
+					t.Fatalf("ReadFile(alpha.md) error = %v", err)
+				}
+				if strings.Contains(string(data), "name:") {
+					t.Errorf("installed file should not contain name: line:\n%s", data)
+				}
+			}
+		})
+	}
+}

--- a/docs/guides/install.md
+++ b/docs/guides/install.md
@@ -49,6 +49,45 @@ The installer is CLI-agnostic. It detects which AI coding CLI(s) are installed a
 
 ---
 
+## Updating
+
+Re-running the installer is how you update devexp — there's no separate "upgrade" command.
+
+- **Binary install**: re-run the `remote-install.sh` one-liner from [Quick install](#quick-install-no-clone). It downloads the latest release binary, overwrites `~/.local/bin/devexp`, and runs `devexp install` again.
+- **Clone install**: `git pull && ./install.sh` rebuilds the CLI from the updated source and re-runs `devexp install`.
+
+### What gets overwritten vs. preserved
+
+- **Agents and skills** are overwritten in place with the versions shipped in the new release. Before overwriting, devexp backs up your existing `~/.claude/agents/*.md` and `~/.claude/skills/<name>/` directories (and the opencode equivalents) into a timestamped `~/.claude/.devexp-backup-<timestamp>/` folder.
+- **MCP server registrations** are *not* refreshed automatically — pass `--reinstall-mcps` if an MCP's config (command, args, env) changed in the new release.
+- **Hooks**: new hooks in `hooks/registry.json` are added to `settings.json`; hooks already registered are left as-is.
+
+### Stale-file cleanup
+
+`devexp install` removes files that a previous run installed but that are no longer part of the current version:
+
+- **Agents and skills**: devexp tracks what it installed in `~/.claude/.devexp-manifest.json` (and `~/.config/opencode/.devexp-manifest.json` for opencode). On each run, anything from the previous manifest that isn't part of this run's install set is removed from disk and dropped from the manifest.
+  - **One-time caveat**: if you're upgrading from a devexp version that predates manifests, the first run after upgrading has no prior manifest to diff against — it just records a baseline. Stale-file cleanup takes effect starting with the *second* run after upgrading.
+- **Hooks**: devexp checks every registered hook command that points into the devexp repo/cache directory. If the backing script no longer exists (because the hook was removed from `hooks/registry.json`), the dangling entry is removed from `settings.json`. User-authored hooks pointing elsewhere are never touched.
+
+### Behavior change: disabling now removes
+
+Previously, disabling an agent or skill in `devexp.config.json` only skipped *updating* it — the old copy stayed on disk. Now a disabled agent/skill is excluded from the install set entirely, so it's treated as stale and **removed** on the next run. If you need a copy, recover it from the backup directory described above.
+
+### Previewing an update
+
+```bash
+./install.sh --dry-run   # or: devexp install --dry-run
+```
+
+Shows every add, update, and removal devexp would make — including stale-file and stale-hook cleanup — without touching any files.
+
+### Scoping an update
+
+`--agents-only`, `--skills-only`, and `--mcps-only` limit *both* the install and the stale-file cleanup to that category — e.g. `--agents-only` won't touch your skills manifest or remove stale skills.
+
+---
+
 ## start-services.sh
 
 Use this after a machine restart or when MCP services have stopped. Never wipes data or venvs.
@@ -90,6 +129,8 @@ After running, reconnect your MCP in Claude Code (`/mcp`) or opencode.
 | `CLAUDE.md` / `AGENTS.md` | `~/.claude/CLAUDE.md` | `~/.config/opencode/AGENTS.md` (or project root) |
 | Agent tools | All Claude tools | `read/write/edit/bash/glob/grep/webfetch/websearch` only |
 | `Agent`, `Skill`, `Task*` tools | Supported | No opencode equivalent — dropped at transform |
+
+> **`.devexp-manifest.json`**: devexp writes `~/.claude/.devexp-manifest.json` and `~/.config/opencode/.devexp-manifest.json` to track which agent/skill files it installed, so future updates can detect and remove files no longer shipped by the toolkit (see [Updating](#updating)). These are managed automatically — don't hand-edit them.
 
 > **opencode users — feature subset:**
 > The following features are unavailable under opencode and are silently dropped at install time:


### PR DESCRIPTION
## Summary
- Re-running `devexp install` now diffs against a per-target manifest (`~/.claude/.devexp-manifest.json`, `~/.config/opencode/.devexp-manifest.json`) and removes agent/skill files no longer shipped in the current version. Skill directories are now backed up before overwrite, matching existing agent backup behavior.
- Hook entries whose backing script was removed from `hooks/registry.json` are pruned from `settings.json`; user-authored hooks are left untouched.
- Bumps CI action versions (`actions/checkout@v6`, `actions/setup-go@v6` with `cache-dependency-path: cli/go.sum`, `goreleaser/goreleaser-action@v7`) to clear the Node 20 deprecation and go.sum cache-restore warnings seen on the v0.2.0 release run.
- Documents the full update/cleanup flow (including the one-time pre-manifest baseline caveat and the "disabling now removes" behavior change) in `docs/guides/install.md`.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./... -race -cover` all pass
- [x] New table-driven tests: `cli/internal/manifest`, `cli/internal/hooks` (prune logic + `InstallClaude`), `cli/internal/skills`, `cli/internal/agents`, plus `TestRemoveStale`/`TestBackupExistingDirs` in `cli/cmd`
- [x] Live smoke test against a fake `HOME`: seeded a stale agent manifest entry → removed on next install; removed a hook script on disk → pruned from `settings.json` on next install, then restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)