### PR TITLE
#36: Document worktree-per-ticket convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,7 @@ Start at [`docs/README.md`](docs/README.md) for the full index.
 | MCP registry format + adding MCPs | [`docs/reference/mcps.md`](docs/reference/mcps.md) |
 | Install / uninstall / start-services | [`docs/guides/install.md`](docs/guides/install.md) |
 | Team distribution + devexp.config.json | [`docs/guides/team-distribution.md`](docs/guides/team-distribution.md) |
+| Worktree-per-ticket delivery convention | [`docs/guides/worktree-per-ticket.md`](docs/guides/worktree-per-ticket.md) |
 | CLAUDE.md-as-indexer pattern | [`docs/guides/docs-architecture.md`](docs/guides/docs-architecture.md) |
 | How to write a new agent | [`docs/development/agent-authoring-guide.md`](docs/development/agent-authoring-guide.md) |
 | How to write a new skill | [`docs/development/skill-authoring-guide.md`](docs/development/skill-authoring-guide.md) |

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ How-to guides for using and configuring the framework.
 | [Docs Architecture](guides/docs-architecture.md) | CLAUDE.md-as-indexer pattern + standard docs/ folder tree — apply this in every project |
 | [Install & Services](guides/install.md) | install.sh flags, start-services.sh, uninstall.sh, and CLI installation paths |
 | [Team Distribution](guides/team-distribution.md) | Fork and customise devexp for your organisation via devexp.config.json |
+| [Worktree-per-Ticket](guides/worktree-per-ticket.md) | How delivery isolates each ticket in its own git worktree — trigger, naming, lifecycle, merge discipline |
 
 → Full index: [docs/guides/README.md](guides/README.md)
 

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -10,6 +10,7 @@ How-to guides for using, configuring, and understanding the devexp framework.
 | [docs-architecture.md](docs-architecture.md) | CLAUDE.md-as-indexer pattern + standard docs/ folder tree — apply this in every project | ready |
 | [install.md](install.md) | install.sh, start-services.sh, uninstall.sh — flags, behavior, CLI paths | ready |
 | [team-distribution.md](team-distribution.md) | Forking and customizing devexp for your organisation via devexp.config.json | ready |
+| [worktree-per-ticket.md](worktree-per-ticket.md) | Worktree-per-ticket delivery convention — trigger, naming scheme, lifecycle, failure handling, merge discipline | ready |
 
 ## Notes
 

--- a/docs/guides/worktree-per-ticket.md
+++ b/docs/guides/worktree-per-ticket.md
@@ -1,0 +1,50 @@
+# Worktree-per-Ticket Convention
+
+The single reference for how the toolkit isolates delivery work using git worktrees. Orchestrators (`/deliver`, `/improve`) point here rather than re-describing the mechanism.
+
+## Why
+
+When a ticket enters delivery, its implementation, tests, and review should not mutate the main working tree. Isolating each ticket in its own worktree keeps the primary checkout clean, lets unrelated work continue uninterrupted, and makes parallelism a free byproduct: two tickets in two worktrees never contend for the same files. The cost is one cheap `git worktree add` at the start and one `git worktree remove` at the end.
+
+## Trigger
+
+A worktree is created **when a ticket enters delivery** — at the start of a `/deliver` run, before any implementation step. No worktree is created for grooming, refinement, or read-only inspection; those operate against the current checkout.
+
+## One worktree per deliverable ticket
+
+The unit of isolation is **one deliverable ticket = one worktree**. A ticket is "deliverable" when it has a verified execution plan and can be implemented, tested, and released on its own.
+
+For an **epic**, the epic itself does not get a worktree — each of its sub-tickets does. Delivering an epic means delivering its sub-tickets in dependency order, each in its own worktree. Because the worktrees are independent, sub-tickets with no dependency between them can be worked in parallel without extra setup — that parallelism falls out of the convention rather than being requested explicitly.
+
+## Naming scheme
+
+Both the worktree directory and its branch are derived from the ticket identifier so the mapping is obvious and collisions are impossible:
+
+- **Branch:** `<type>/<ticket-id>` — the same branch convention delivery already uses (e.g. a feature branch for a feature ticket, a fix branch for a bug ticket).
+- **Worktree directory:** a sibling of the main checkout, named for the ticket — e.g. `../<repo>-worktrees/<ticket-id>`. Placing worktrees **outside** the primary working tree keeps them from being scanned, indexed, or accidentally committed into the main checkout.
+
+Deriving both names from the ticket id means a glance at `git worktree list` shows exactly which ticket each tree belongs to.
+
+## Lifecycle
+
+```
+create  →  work  →  merge (at release gate)  →  remove
+```
+
+1. **Create** — at `/deliver` start, add a worktree on a fresh branch derived from the ticket id.
+2. **Work** — implementation, instrumentation, test-gap filling, and code review all run *inside* the worktree. The main checkout is never touched during this phase.
+3. **Merge** — deferred to the **release gate**. Only when the ticket is approved and ready to release is the branch merged back. Merges are never performed mid-delivery.
+4. **Remove** — on a **successful** release, the worktree and its branch are removed automatically; the toolkit cleans up after itself so finished trees don't accumulate.
+
+## Failure handling
+
+If delivery fails at any step — failing tests, an unresolved review finding, an aborted release — the worktree is **kept, not removed**. The isolated tree preserves the exact state where work stopped so it can be inspected, resumed, or diagnosed. Cleanup of a failed worktree is a deliberate, separate action, never automatic.
+
+## Merge discipline
+
+- **Merges are serialized.** When multiple worktrees are ready to merge, they merge one at a time, never concurrently, so each merge sees a consistent base.
+- **Conflicts surface to the user.** A merge conflict is always raised for the user to resolve. The toolkit **never auto-resolves** conflicts — silently picking a side risks discarding correct work.
+
+## Single-stream / no-isolation note
+
+Worktree isolation is the default for delivery, but it is not mandatory in every environment. When isolation is unavailable or unwanted — a single-stream setup, a shallow or non-worktree-capable checkout, or a one-off change the user explicitly wants applied to the current tree — delivery may proceed **in place** on the current branch. In that mode the lifecycle collapses to work → release on the existing checkout, the merge step is a no-op, and the same merge discipline (serialized, conflicts surfaced) still applies to whatever integration happens.


### PR DESCRIPTION
Closes #36 · part of #32 (epic: fresh memory, worktree-per-ticket delivery, completion cleanup).

## What
Adds `docs/guides/worktree-per-ticket.md` — the single shared reference for the worktree-per-ticket delivery convention that B2 (#37) and B3 (#38) will wire into `/deliver` and `/improve`.

## Acceptance Criteria
- [x] New doc under `docs/guides/` covers trigger, naming scheme, lifecycle (create→work→merge-at-release-gate→remove), failure handling (keep worktree on failure)
- [x] Single-stream/no-isolation note + each epic sub-ticket gets its own worktree
- [x] Merges serialized; conflicts surface to the user, never auto-resolved
- [x] Linked from `docs/README.md`, `docs/guides/README.md`, and the CLAUDE.md doc table
- [x] Tool-agnostic — no specific git host named

## Notes
Docs-only; no runtime code, so no observability/test phases and no `install.sh` redeploy (only `docs/` + `CLAUDE.md` touched). Delivered in-place on a branch rather than a worktree, since the worktree flow this doc describes isn't wired into `/deliver` yet (#37) — the doc's "single-stream" fallback explicitly permits this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)