### PR TITLE
#33 follow-up: pin drift-classification --since to start-of-day

### DIFF
--- a/agents/codebase-navigator.md
+++ b/agents/codebase-navigator.md
@@ -162,7 +162,8 @@ The canonical drift rule. **A2** (the freshness gate on atlas consumers) and **A
 1. Read the atlas's `Last updated:` date.
 2. List the paths changed since then:
    ```
-   git log --since="<Last updated>" --name-only --pretty=format: | sort -u | sed '/^$/d'
+   # Pin to start-of-day: a bare date makes git's --since exclude commits made later on the Last-updated day.
+   git log --since="<Last updated> 00:00:00" --name-only --pretty=format: | sort -u | sed '/^$/d'
    ```
 3. Classify by what those paths touch:
    - **No paths** (no commits since `Last updated`) → **CURRENT** — use the atlas as-is. No git scan beyond this, no rebuild.
@@ -178,7 +179,7 @@ A changed path is **structural** if it is *named in*, or *lives under a director
 
 ### Incremental Update Procedure
 
-1. For each dated entry in `## Known Technical Debt` / `## Gotchas`, run `git log --since="<entry-date>" --oneline --name-only -- <path-from-entry>` (dedupe paths first)
+1. For each dated entry in `## Known Technical Debt` / `## Gotchas`, run `git log --since="<entry-date> 00:00:00" --oneline --name-only -- <path-from-entry>` (dedupe paths first; the `00:00:00` keeps same-day commits in range)
 2. For entries whose path has commits since their date:
    - Resolved → remove the entry
    - Still an issue but details changed → update description, bump date to today


### PR DESCRIPTION
Follow-up to #43 (merged) addressing the pr-review nit. Part of #33.

## Problem
The Drift Classification command introduced in #43 uses `git log --since="<Last updated>"` with a **bare date**. Git's date parser excludes commits made later on that same day — so an atlas updated in the morning, with commits landing that afternoon, falsely classifies as **CURRENT** and skips its incremental update until the next calendar day. Minor and pre-existing, but it now lives in the **canonical rule that A2 (#34) and A3 (#35) reuse verbatim** — so it's hardened at the source before those tickets copy it.

## Fix
Pin `--since` to start-of-day (`"<Last updated> 00:00:00"`) in both freshness commands:
- the canonical `### Drift Classification` command
- the Incremental Update Procedure per-entry command

## Verified
On this repo at HEAD (committed `2026-06-15`):
- `--since="2026-06-15"` → **0** commits (the false-CURRENT bug)
- `--since="2026-06-15 00:00:00"` → **4** commits (correct — same-day commits in range)

🤖 Generated with [Claude Code](https://claude.com/claude-code)