### PR TITLE
#34: Freshness gate on atlas consumers

### DIFF
--- a/agents/dev-agent.md
+++ b/agents/dev-agent.md
@@ -42,7 +42,12 @@ When receiving a task, immediately classify it:
 
 ### Step 1: Orient (always, every task)
 Before writing a single line of code:
-1. Check if `codebase-navigator` agent has a recent atlas for this project at `~/.claude/agent-memory/codebase-navigator/`. If so, read the relevant project atlas file — it tells you the layer map, conventions, canonical example, and entry points.
+1. Check if `codebase-navigator` agent has an atlas for this project at `~/.claude/agent-memory/codebase-navigator/`. If one exists, **run the freshness gate before trusting it** — apply codebase-navigator's canonical **Drift Classification** (defined in its Memory Protocol; reference that rule, never reimplement it) against the atlas's `Last updated` date:
+   - **CURRENT** (no commits since `Last updated`) → use the atlas as-is, no added latency.
+   - **SMALL** (only peripheral paths changed) → re-validate just the changed sections, and only if they overlap **this task's scope** (the layer and files you're about to touch); otherwise use the atlas as-is.
+   - **BIG** (structural sections changed) → delegate a full rebuild to `codebase-navigator` before planning, then read the refreshed atlas.
+
+   Once the gate passes, read the relevant project atlas file — it tells you the layer map, conventions, canonical example, and entry points.
 2. If no atlas exists, do a **targeted orientation** covering: what layer does this task touch? What are the naming conventions in that layer? What does the nearest similar implementation look like? (Not a full atlas — delegate that to codebase-navigator when there's time.)
 3. Find the **canonical example** — the best existing implementation of something similar to what you're building. Your output must be indistinguishable in style from this reference.
 4. Check for an existing knowledge graph: if `graphify-out/graph.json` exists, run `graphify query "<task description> conventions patterns known issues"` and surface any prior bug root causes, conventions, or known debt relevant to the layer you're touching.

--- a/agents/grooming-agent.md
+++ b/agents/grooming-agent.md
@@ -32,10 +32,10 @@ cat ~/.claude/agent-memory/codebase-navigator/MEMORY.md 2>/dev/null
 
 If an atlas exists for this project, **run the freshness gate before trusting it** — apply codebase-navigator's canonical **Drift Classification** (defined in its Memory Protocol; reference that rule, never duplicate it) against the atlas's `Last updated` date:
 - **CURRENT** (no commits since `Last updated`) → read the atlas as-is, no added latency.
-- **SMALL** (only peripheral paths changed) → re-validate just the changed sections that overlap the **ticket's scope** (the files/layers the ticket claims to touch); otherwise read as-is.
+- **SMALL** (only peripheral paths changed) → re-validate just the changed sections, and only if they overlap the **ticket's scope** (the files/layers the ticket claims to touch); otherwise read as-is.
 - **BIG** (structural sections changed) → spawn `codebase-navigator` for a full rebuild before grooming, then use the refreshed atlas.
 
-It gives you the layer map, module structure, and conventions. If no atlas exists, spawn `codebase-navigator` first:
+The atlas gives you the layer map, module structure, and conventions. If no atlas exists, spawn `codebase-navigator` first:
 
 > "Map the codebase structure, identify all layers, modules, entry points, and conventions. I need this before grooming a ticket."
 

--- a/agents/grooming-agent.md
+++ b/agents/grooming-agent.md
@@ -30,7 +30,12 @@ Check if `codebase-navigator` has already mapped this project:
 cat ~/.claude/agent-memory/codebase-navigator/MEMORY.md 2>/dev/null
 ```
 
-If an atlas exists for this project, read it — it gives you the layer map, module structure, and conventions. If it doesn't exist, spawn `codebase-navigator` first:
+If an atlas exists for this project, **run the freshness gate before trusting it** — apply codebase-navigator's canonical **Drift Classification** (defined in its Memory Protocol; reference that rule, never duplicate it) against the atlas's `Last updated` date:
+- **CURRENT** (no commits since `Last updated`) → read the atlas as-is, no added latency.
+- **SMALL** (only peripheral paths changed) → re-validate just the changed sections that overlap the **ticket's scope** (the files/layers the ticket claims to touch); otherwise read as-is.
+- **BIG** (structural sections changed) → spawn `codebase-navigator` for a full rebuild before grooming, then use the refreshed atlas.
+
+It gives you the layer map, module structure, and conventions. If no atlas exists, spawn `codebase-navigator` first:
 
 > "Map the codebase structure, identify all layers, modules, entry points, and conventions. I need this before grooming a ticket."
 


### PR DESCRIPTION
Closes #34 · part of #32 · depends on #33 (A1, merged).

## What
`dev-agent` and `grooming-agent` consumed the codebase-navigator atlas blindly (`dev-agent.md:45` read "a recent atlas" with no check; `grooming-agent.md:33` read it if it existed). After a few commits they planned against a stale map. This adds a freshness gate that runs A1's canonical Drift Classification before consuming the atlas.

## Gate behavior (both consumers)
- **CURRENT** — no commits since `Last updated` → use atlas as-is, **no added latency**
- **SMALL** — only peripheral paths changed → re-validate just the changed sections, **and only if they overlap the task's/ticket's scope**; otherwise as-is
- **BIG** — structural sections changed → delegate a full rebuild to `codebase-navigator` before planning

## Acceptance Criteria
- [x] `dev-agent` and `grooming-agent` run the cheap A1 freshness gate before consuming the atlas
- [x] SMALL → re-validate only changed sections, only if they overlap scope
- [x] BIG → trigger full rebuild via codebase-navigator before planning
- [x] No drift → behavior unchanged, no added latency
- [x] Tests — verified (see note)

## Non-Goal honored
Classification logic is **referenced, not duplicated**: the `git log --since` command stays single-sourced in codebase-navigator (3 usages, all in its canonical home); consumers act only on the CURRENT/SMALL/BIG verdict. Verified by grep — neither consumer contains the classification command.

## Note on "tests"
Agent-prose change, no executable unit. Verified structurally: both consumers reference the canonical "Drift Classification", carry all three verdicts, include scope-overlap gating, and reimplement no `--since` command. No Go code touched; CLI suite stays green.

Delivered via worktree `feat/34-freshness-gate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)