### PR TITLE
#35: Anchor plans to commit SHA; deliver re-grooms on big drift

### DIFF
--- a/agents/grooming-agent.md
+++ b/agents/grooming-agent.md
@@ -262,6 +262,21 @@ Pass all Phase 3–6 findings as context. The plan must:
 - Have ordered steps — each step unblocked by the previous
 - Have a specific verification section (not "run tests" — specific commands and what to check)
 
+**Stamp the plan with a validation anchor.** Every line/path in the plan was verified against a specific commit; record which one so consumers can detect drift later. Capture it:
+
+```bash
+git rev-parse HEAD              # full SHA the plan was validated against
+git rev-parse --abbrev-ref HEAD # branch
+```
+
+The plan's header must carry an anchor line:
+
+```
+**Validated against:** commit `<full-sha>` (`<branch>`) · <date>
+```
+
+This anchor is part of the plan body, so it travels to every destination in Phase 8 — the ticket-platform copy **and** the local copy. `deliver` Phase 0 reads it to decide whether the plan is still trustworthy or needs a re-groom.
+
 ---
 
 ### Phase 8: Persist
@@ -276,6 +291,8 @@ Write the plan to `~/.claude/agent-memory/grooming-agent/plans/<TICKET-ID>.md`. 
 /graphify --update
 ```
 If there's no graph, or graphify is unavailable, skip the rebuild — the ticket platform and the local copy are sufficient.
+
+Both copies must retain the **Validated against** anchor from Phase 7 verbatim — never strip it from either destination. It is what lets `deliver` re-anchor the plan to current HEAD.
 
 ---
 

--- a/agents/grooming-agent.md
+++ b/agents/grooming-agent.md
@@ -166,6 +166,7 @@ Collect all agent findings. Produce a **Ticket Health Report**:
 **Ticket**: <Title>
 **Type**: <Classification from Phase 2>
 **Groomed**: <date>
+**Validated against**: commit `<full-sha>` (`<branch>`)
 
 ---
 
@@ -269,13 +270,7 @@ git rev-parse HEAD              # full SHA the plan was validated against
 git rev-parse --abbrev-ref HEAD # branch
 ```
 
-The plan's header must carry an anchor line:
-
-```
-**Validated against:** commit `<full-sha>` (`<branch>`) · <date>
-```
-
-This anchor is part of the plan body, so it travels to every destination in Phase 8 — the ticket-platform copy **and** the local copy. `deliver` Phase 0 reads it to decide whether the plan is still trustworthy or needs a re-groom.
+Record it in the **`**Validated against**:` field of the Ticket Health Report header** (alongside `**Groomed**:`, see the template above) and carry that same header into the persisted plan. Because the anchor lives in the plan body, it travels to every destination in Phase 8 — the ticket-platform copy **and** the local copy. `deliver` Phase 0 reads it to decide whether the plan is still trustworthy or needs a re-groom.
 
 ---
 

--- a/skills/deliver/SKILL.md
+++ b/skills/deliver/SKILL.md
@@ -49,8 +49,14 @@ Wait for the grooming-agent to complete before proceeding.
 
 ```bash
 anchor="<sha-from-plan-anchor>"
-git rev-parse HEAD                                          # current HEAD
-git log "${anchor}..HEAD" --name-only --pretty=format: | sort -u | sed '/^$/d'   # paths changed since the plan was validated
+# The commit range is precise only if the anchor is an ancestor of HEAD.
+# If the SHA is missing (history rewritten) or not an ancestor (diverged branch),
+# fall back to the date-based classification so drift is never understated.
+if git merge-base --is-ancestor "$anchor" HEAD 2>/dev/null; then
+  git log "${anchor}..HEAD" --name-only --pretty=format: | sort -u | sed '/^$/d'   # paths changed since the plan was validated
+else
+  echo "anchor not an ancestor of HEAD — use the date fallback below"
+fi
 ```
 
 | Drift since anchor | Action |
@@ -59,7 +65,7 @@ git log "${anchor}..HEAD" --name-only --pretty=format: | sort -u | sed '/^$/d'  
 | **SMALL** — only peripheral paths changed | Proceed, but note the scoped deltas to the user and re-verify any plan step that touches a changed path |
 | **BIG** — a structural section's paths changed | The plan may be built on a stale map — **re-groom before building** (invoke `grooming-agent` as above), then reload the refreshed plan |
 
-If the plan has no anchor (groomed before A3), treat it as drift-unknown: run the classification against the plan's `Groomed:`/`Last updated` date instead, and prefer re-grooming if the date is not same-day.
+If the plan has no anchor (groomed before A3), or the anchor is not an ancestor of HEAD (per the guard above), treat it as drift-unknown: run the classification against the plan's `Groomed` date instead (`git log --since="<Groomed date> 00:00:00" --name-only`), and prefer re-grooming if that date is not same-day.
 
 ---
 

--- a/skills/deliver/SKILL.md
+++ b/skills/deliver/SKILL.md
@@ -45,6 +45,22 @@ If the groom plan is missing: invoke the `grooming-agent`:
 
 Wait for the grooming-agent to complete before proceeding.
 
+**Re-anchor the plan to current HEAD.** A persisted plan was validated against a specific commit (the **Validated against** anchor `grooming-agent` stamps into the plan header). Code may have moved since, so before trusting the plan, classify the drift between that anchor and HEAD using codebase-navigator's canonical **Drift Classification** (the same structural-section rule from A1 — reference it, don't reimplement), sourcing the changed paths from the commit range rather than a date:
+
+```bash
+anchor="<sha-from-plan-anchor>"
+git rev-parse HEAD                                          # current HEAD
+git log "${anchor}..HEAD" --name-only --pretty=format: | sort -u | sed '/^$/d'   # paths changed since the plan was validated
+```
+
+| Drift since anchor | Action |
+|--------------------|--------|
+| **CURRENT** — HEAD == anchor, no commits | Use the plan as-is |
+| **SMALL** — only peripheral paths changed | Proceed, but note the scoped deltas to the user and re-verify any plan step that touches a changed path |
+| **BIG** — a structural section's paths changed | The plan may be built on a stale map — **re-groom before building** (invoke `grooming-agent` as above), then reload the refreshed plan |
+
+If the plan has no anchor (groomed before A3), treat it as drift-unknown: run the classification against the plan's `Groomed:`/`Last updated` date instead, and prefer re-grooming if the date is not same-day.
+
 ---
 
 ### Phase 1 — Assess and Present the Delivery Plan


### PR DESCRIPTION
Closes #35 · part of #32 · depends on #33 (A1, merged). Completes the memory-freshness track (A).

## What
`grooming-agent` wrote execution plans that `deliver` Phase 0 trusted with no re-anchor to current HEAD — so a plan went stale the moment code changed. This stamps every plan with the commit it was validated against, and has `deliver` re-classify drift before building.

## Changes
- **grooming-agent Phase 7**: stamps each plan with a `**Validated against:** commit <sha> (<branch>) · <date>` anchor in the header.
- **grooming-agent Phase 8**: anchor retained verbatim in both the ticket-platform copy and the local copy.
- **deliver Phase 0**: re-anchors the plan — classifies drift between the anchor SHA and HEAD via A1's canonical Drift Classification (sourced from the commit range `<anchor>..HEAD`):
  - **CURRENT** (HEAD == anchor) → use plan as-is
  - **SMALL** (peripheral paths) → proceed, note scoped deltas, re-verify steps touching changed paths
  - **BIG** (structural paths) → re-groom before building, reload refreshed plan
- Pre-A3 plans without an anchor fall back to the `Groomed`/`Last updated` date.

## Acceptance Criteria
- [x] grooming-agent stamps each persisted plan with HEAD SHA + date
- [x] deliver Phase 0 compares anchor to HEAD using A1's classification
- [x] SMALL → proceed noting deltas; BIG → re-groom before building
- [x] Anchor recorded in both platform plan and local copy
- [x] Tests — dry-run verified (see note)

## Non-Goal honored
Drift logic is **referenced, not duplicated**: deliver points to A1's structural-section rule and does not enumerate Layer Map / Canonical Example / etc. (verified by grep). Auto-resolving plan/code conflicts is out of scope — BIG drift re-grooms, it does not silently reconcile.

## Note on "tests"
Agent/skill prose change. Verified by dry-running the commit-range classification against this repo: `<anchor>..HEAD` yields the changed-path set; `HEAD..HEAD` is empty → CURRENT. No Go code touched; CLI suite stays green.

Delivered via worktree `feat/35-plan-anchor`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)