### PR TITLE
#38: Wire worktree awareness into improve cleanup streams

### DIFF
--- a/skills/improve/SKILL.md
+++ b/skills/improve/SKILL.md
@@ -265,6 +265,8 @@ Agent-memory duplication found:
 
 Do not delete anything automatically — surface findings only.
 
+**Applying accepted cleanup — worktree isolation.** `/improve` surfaces findings; it never edits on its own. When the user accepts findings and asks to apply them, and the work splits into **independent streams that mutate files in parallel** (e.g. dead-code removal, doc refresh, and debt fixes running concurrently), isolate each stream in its own git worktree per the **worktree-per-ticket convention** (`docs/guides/worktree-per-ticket.md`) — one worktree per stream, each branched off the cleanup base. Streams **merge serially** back to the base; any conflict **surfaces to the user and is never auto-resolved**. A findings-only run, a single stream, or a trivial one-file fix runs in place — **no worktree overhead**.
+
 ---
 
 ### Phase 4 — Tech Debt Triage  *(optional)*
@@ -346,6 +348,7 @@ Next cycle:
 
 - **Health always runs** — it's the minimum viable maintenance action; everything else is optional
 - **Never auto-delete** — stale work and dead code scans produce findings for human review, not automated removal
+- **Isolate parallel cleanup in worktrees** — when applying accepted findings across independent streams concurrently, each stream gets its own worktree ([`docs/guides/worktree-per-ticket.md`](../../docs/guides/worktree-per-ticket.md)), merged serially with conflicts surfaced to the user; findings-only and single-stream runs stay in place with no overhead
 - **CI failure pre-empts everything** — a failing pipeline invalidates the health scorecard's CI dimension; address it first
 - **Retrospective items need evidence** — if you can't point to a git commit, health metric, or incident, the item is a feeling, not a finding
 - **Trend direction matters more than absolute score** — a project with 65% coverage improving (↑) is in better shape than one at 80% degrading (↓)


### PR DESCRIPTION
Closes #38 · part of #32 · depends on #36 (B1, merged).

## What
When `/improve` applies accepted cleanup findings across **independent streams that mutate files in parallel** (dead-code removal, doc refresh, debt fixes), each stream now runs in its own git worktree per the B1 convention. Streams merge serially; conflicts surface to the user and are never auto-resolved. Findings-only, single-stream, and trivial runs stay in place — no worktree overhead.

## Changes to `skills/improve/SKILL.md`
- New "Applying accepted cleanup — worktree isolation" note after the Phase 3 cleanup checklist.
- New Guidelines bullet anchoring the rule and pointing to `docs/guides/worktree-per-ticket.md`.

## Acceptance Criteria
- [x] Each parallel cleanup stream runs in its own worktree (B1 convention)
- [x] Streams merge serially; conflicts surface to the user
- [x] Single-stream / trivial runs incur no worktree overhead
- [x] Tests — structural verification (see note)

## Grooming finding (surfaced, not silently implemented)
The ticket states improve "runs parallel cleanup streams ... concurrent edits can collide." In the **current** skill, improve is **findings-first** — it surfaces a cleanup checklist and never auto-deletes (Guideline: *"Never auto-delete"*; line "Do not delete anything automatically — surface findings only"). So there are no concurrent edits *today*. This PR therefore wires the **apply-fix path**: the isolation rule applies when the user accepts findings and improve applies them across independent streams — which is exactly what the C2 repo-wide hygiene sweep (#40, next) will exercise. The common findings-only run correctly incurs zero worktree overhead, satisfying that AC directly.

## Non-Goal honored
The repo-wide hygiene sweep itself is C2/#40 — not in this PR. References the B1 convention rather than restating the lifecycle.

## Note on "tests"
Skill-prose change, no executable unit. Verified structurally: all four AC behaviors present, references the canonical convention doc, no Go code touched (CLI suite stays green).

Delivered via worktree `feat/38-improve-worktree`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)