### PR TITLE
#39: deliver final-phase cleanup (retire ticket artifacts + /tmp)

### DIFF
--- a/skills/deliver/SKILL.md
+++ b/skills/deliver/SKILL.md
@@ -391,18 +391,33 @@ glab release create "v<version>" --name "v<version>" --notes "<changelog entry>"
 
 Once the release succeeds, retire the artifacts **this** delivery created so they don't linger and drift from reality. **Gate strictly on success** — if delivery failed or was aborted at any earlier step, **skip this phase entirely and preserve everything** (worktree, plan, scratch) for inspection. Scope every action to this ticket; the repo-wide sweep of orphaned artifacts belongs to `/improve` (C2), not here.
 
+**Safety gate — bind and verify the ticket id before any deletion.** Every `rm` below is keyed to `$ticket`. An empty id would turn an id-scoped glob into a blanket wipe (`/tmp/*$ticket*` → `/tmp/*`), so **abort cleanup entirely if the id is empty** — never run a delete with an unset id. Use the same `ticket` variable bound in Phase 1.5, and re-assert it here:
+
+```bash
+ticket="<ticket-id>"
+case "$ticket" in
+  ""|*[!A-Za-z0-9_-]*) echo "ticket id missing or unsafe — skipping all artifact cleanup"; return 2>/dev/null || exit 0 ;;
+esac
+```
+
+With `$ticket` verified non-empty and safe, retire each artifact:
+
 1. **Worktree** — already removed in Phase 6a on a successful release; confirm it's gone:
    ```bash
    git worktree list   # this ticket's tree should no longer appear (nothing to do if the run was single-stream)
    ```
-2. **Persisted plan (per A3)** — the plan described pre-merge intent; once delivered it only invites drift. Remove the local copy; remove the ticket-platform copy too (ask first, since it's shared):
+2. **Persisted plan (per A3)** — the plan described pre-merge intent; once delivered it only invites drift. Remove the local copy:
    ```bash
-   rm -f ~/.claude/agent-memory/grooming-agent/plans/<TICKET-ID>.md
+   rm -f ~/.claude/agent-memory/grooming-agent/plans/"$ticket".md
    ```
-3. **Groom-session artifacts** — remove transient grooming session/scratch files keyed to `<TICKET-ID>` under `~/.claude/agent-memory/grooming-agent/`. Never delete the project's shared `<PROJECT-NAME>.md` memory — that's not ticket-scoped.
-4. **/tmp scratch** — remove only the scratch files **this run** wrote under `/tmp` (heredoc bodies, plan scratch, temp diffs). Match by ticket id or this session — never a blanket `/tmp` wipe:
+   The ticket-platform copy is a tracker action, not a filesystem delete — **ask the user first** (it's shared), then remove it via the platform's API/CLI.
+3. **Groom-session artifacts** — remove transient grooming session/scratch files keyed to `$ticket`. Scope the glob to the id so it can never match the project's shared `<PROJECT-NAME>.md` memory (which is not ticket-scoped and must survive):
    ```bash
-   rm -f /tmp/*<TICKET-ID>* /tmp/.deliver-<TICKET-ID>-* 2>/dev/null
+   rm -f ~/.claude/agent-memory/grooming-agent/sessions/*"$ticket"* ~/.claude/agent-memory/grooming-agent/*"$ticket"*.scratch 2>/dev/null
+   ```
+4. **/tmp scratch** — remove only the scratch files **this run** wrote under `/tmp` (heredoc bodies, plan scratch, temp diffs), matched by the verified id — never a blanket `/tmp` wipe:
+   ```bash
+   rm -f /tmp/*"$ticket"* /tmp/".deliver-$ticket-"* 2>/dev/null
    ```
 5. **Agent-memory entries** — prune or refresh agent-memory entries tied **to this ticket only**, and **only when drift/staleness warrants it** (the delivered work changed something an entry described): re-date re-verified entries, remove resolved ones, leave the rest. Entries unrelated to this ticket are out of scope — that's C2.
 

--- a/skills/deliver/SKILL.md
+++ b/skills/deliver/SKILL.md
@@ -191,7 +191,7 @@ If no logging library is detected in the project, note it and skip — do not ad
 
 **3d. Surface SLO candidates:**
 
-For each new or modified critical path identified above (API handler, background job, external call, DB write), note the natural SLI attachment point — what would a team measure here (latency, error rate, throughput, queue depth)? List these as candidates in the Phase 7 report. Do not create dashboards, alert configs, or metric code — just surface what exists as observable points so the team can wire them up.
+For each new or modified critical path identified above (API handler, background job, external call, DB write), note the natural SLI attachment point — what would a team measure here (latency, error rate, throughput, queue depth)? List these as candidates in the Phase 8 report. Do not create dashboards, alert configs, or metric code — just surface what exists as observable points so the team can wire them up.
 
 ---
 
@@ -228,7 +228,7 @@ find . -maxdepth 4 -name "*.spec.*" -o -name "*.e2e.*" -o -name "*_test.*" 2>/de
 ```
 
 - If an E2E suite exists: check whether the user flows touched by this ticket have corresponding E2E scenarios. If gaps exist, read 2–3 existing E2E test files to learn the project's conventions, then generate scenarios that cover the changed flows.
-- If no E2E suite exists: note the gap in the Phase 7 report. Do not scaffold an E2E framework unilaterally.
+- If no E2E suite exists: note the gap in the Phase 8 report. Do not scaffold an E2E framework unilaterally.
 
 **Regression check:**
 
@@ -254,7 +254,7 @@ If new or modified endpoints are detected, check whether the project has a load 
 find . -maxdepth 4 \( -name "*.k6.js" -o -name "locustfile*" -o -name "artillery*" -o -name "*.gatling.*" \) 2>/dev/null | grep -v node_modules | head -3
 ```
 
-If a framework exists: offer to generate load test scenarios (smoke / load / stress) for the new endpoints. If the user confirms, read 1-2 existing test files to learn the format, then generate scenarios. If no framework exists: note the gap in the Phase 7 report.
+If a framework exists: offer to generate load test scenarios (smoke / load / stress) for the new endpoints. If the user confirms, read 1-2 existing test files to learn the format, then generate scenarios. If no framework exists: note the gap in the Phase 8 report.
 
 ---
 
@@ -387,7 +387,30 @@ glab release create "v<version>" --name "v<version>" --notes "<changelog entry>"
 
 ---
 
-### Phase 7 — Report & Hand Off
+### Phase 7 — Retire Delivery Artifacts  *(on successful completion only)*
+
+Once the release succeeds, retire the artifacts **this** delivery created so they don't linger and drift from reality. **Gate strictly on success** — if delivery failed or was aborted at any earlier step, **skip this phase entirely and preserve everything** (worktree, plan, scratch) for inspection. Scope every action to this ticket; the repo-wide sweep of orphaned artifacts belongs to `/improve` (C2), not here.
+
+1. **Worktree** — already removed in Phase 6a on a successful release; confirm it's gone:
+   ```bash
+   git worktree list   # this ticket's tree should no longer appear (nothing to do if the run was single-stream)
+   ```
+2. **Persisted plan (per A3)** — the plan described pre-merge intent; once delivered it only invites drift. Remove the local copy; remove the ticket-platform copy too (ask first, since it's shared):
+   ```bash
+   rm -f ~/.claude/agent-memory/grooming-agent/plans/<TICKET-ID>.md
+   ```
+3. **Groom-session artifacts** — remove transient grooming session/scratch files keyed to `<TICKET-ID>` under `~/.claude/agent-memory/grooming-agent/`. Never delete the project's shared `<PROJECT-NAME>.md` memory — that's not ticket-scoped.
+4. **/tmp scratch** — remove only the scratch files **this run** wrote under `/tmp` (heredoc bodies, plan scratch, temp diffs). Match by ticket id or this session — never a blanket `/tmp` wipe:
+   ```bash
+   rm -f /tmp/*<TICKET-ID>* /tmp/.deliver-<TICKET-ID>-* 2>/dev/null
+   ```
+5. **Agent-memory entries** — prune or refresh agent-memory entries tied **to this ticket only**, and **only when drift/staleness warrants it** (the delivered work changed something an entry described): re-date re-verified entries, remove resolved ones, leave the rest. Entries unrelated to this ticket are out of scope — that's C2.
+
+Record what was retired in the Phase 8 report.
+
+---
+
+### Phase 8 — Report & Hand Off
 
 ```
 ## Delivered: <ticket-id> — "<title>"
@@ -401,6 +424,7 @@ glab release create "v<version>" --name "v<version>" --notes "<changelog entry>"
   E2E coverage:    <N scenarios added / no E2E suite detected / already covered>
   Review:          <findings addressed / approved>
   Release:         v<version> published / pending manual release
+  Cleanup:         <worktree + plan + groom session + /tmp retired / preserved — delivery failed>
 
 Next:
   /improve   — run a health check now that new code is live


### PR DESCRIPTION
Closes #39 · part of #32 · depends on #35 (A3) + #37 (B2), both merged.

## What
When a delivery finishes, its artifacts (worktree, persisted plan, groom session, ticket memory, `/tmp` scratch) lingered and drifted. Adds a final cleanup phase to `deliver` that retires **this ticket's** artifacts on success only.

## Changes to `skills/deliver/SKILL.md`
- **New Phase 7 — Retire Delivery Artifacts** (gated on successful completion):
  1. Worktree — confirms the Phase 6a removal (nothing if single-stream)
  2. Persisted plan + local copy (per A3); ticket-platform copy removed on confirm
  3. Groom-session scratch keyed to the ticket (never the shared `<PROJECT>.md` memory)
  4. `/tmp` scratch this run wrote — scoped by ticket id/session, **never a blanket wipe**
  5. Agent-memory entries tied to this ticket, **only when drift/staleness warrants**
- **On failed/aborted delivery** → phase skipped entirely, everything preserved.
- Report phase renumbered **Phase 7 → Phase 8**; the three in-skill "Phase 7 report" references updated; new `Cleanup:` line added to the report.

## Acceptance Criteria
- [x] deliver gains a final cleanup phase that runs on successful completion
- [x] Retires this ticket's worktree (B2), persisted plan + local copy (A3), groom-session artifacts
- [x] Removes `/tmp` scratch the delivery wrote (scoped, no blanket wipe)
- [x] Prunes/refreshes ticket-tied agent-memory only when drift/staleness warrants
- [x] On failed/aborted delivery, artifacts preserved
- [x] Tests — structural verification (see note)

## Non-Goal honored
Repo-wide sweep of orphaned artifacts is C2/#40 — explicitly out of scope; this phase only touches artifacts keyed to the current ticket.

## Note on "tests"
Skill-prose change, no executable unit. Verified structurally: all six AC behaviors present, cleanup gated on success, `/tmp` removal scoped (no blanket wipe), zero stale phase-number references after renumber. No Go code touched.

Delivered via worktree `feat/39-deliver-cleanup`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)