### PR TITLE
#40: improve repo-wide hygiene sweep (C2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,7 @@ Start at [`docs/README.md`](docs/README.md) for the full index.
 | Install / uninstall / start-services | [`docs/guides/install.md`](docs/guides/install.md) |
 | Team distribution + devexp.config.json | [`docs/guides/team-distribution.md`](docs/guides/team-distribution.md) |
 | Worktree-per-ticket delivery convention | [`docs/guides/worktree-per-ticket.md`](docs/guides/worktree-per-ticket.md) |
+| Cleanup safety rules (deletion guards) | [`docs/guides/cleanup-safety.md`](docs/guides/cleanup-safety.md) |
 | CLAUDE.md-as-indexer pattern | [`docs/guides/docs-architecture.md`](docs/guides/docs-architecture.md) |
 | How to write a new agent | [`docs/development/agent-authoring-guide.md`](docs/development/agent-authoring-guide.md) |
 | How to write a new skill | [`docs/development/skill-authoring-guide.md`](docs/development/skill-authoring-guide.md) |

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ How-to guides for using and configuring the framework.
 | [Install & Services](guides/install.md) | install.sh flags, start-services.sh, uninstall.sh, and CLI installation paths |
 | [Team Distribution](guides/team-distribution.md) | Fork and customise devexp for your organisation via devexp.config.json |
 | [Worktree-per-Ticket](guides/worktree-per-ticket.md) | How delivery isolates each ticket in its own git worktree — trigger, naming, lifecycle, merge discipline |
+| [Cleanup Safety](guides/cleanup-safety.md) | Rules for safely deleting artifacts — dry-run, id guards, never touch shared state — followed by deliver C1 + improve C2 |
 
 → Full index: [docs/guides/README.md](guides/README.md)
 

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -11,6 +11,7 @@ How-to guides for using, configuring, and understanding the devexp framework.
 | [install.md](install.md) | install.sh, start-services.sh, uninstall.sh — flags, behavior, CLI paths | ready |
 | [team-distribution.md](team-distribution.md) | Forking and customizing devexp for your organisation via devexp.config.json | ready |
 | [worktree-per-ticket.md](worktree-per-ticket.md) | Worktree-per-ticket delivery convention — trigger, naming scheme, lifecycle, failure handling, merge discipline | ready |
+| [cleanup-safety.md](cleanup-safety.md) | Canonical deletion-safety rules for toolkit cleanup — dry-run, scoped id guards, shared-state protection, staleness-gated memory pruning | ready |
 
 ## Notes
 

--- a/docs/guides/cleanup-safety.md
+++ b/docs/guides/cleanup-safety.md
@@ -1,0 +1,31 @@
+# Cleanup Safety
+
+The single reference for how the toolkit deletes artifacts safely. Both cleanup paths point here: `/deliver`'s per-ticket final phase (C1) and `/improve`'s repo-wide hygiene sweep (C2). Any step that removes files, branches, worktrees, or memory entries follows these rules — they exist because a wrong glob or an unset variable can destroy user data.
+
+## The rules
+
+1. **Dry-run first — list before you delete.** Enumerate every candidate and show it to the user before removing anything. A sweep that deletes before reporting is never correct.
+
+2. **Confirm or log every destructive action.** Removal requires explicit user confirmation, or — when running in an already-confirmed/flagged mode — a clear line-by-line log of exactly what was removed. Silent deletion is forbidden.
+
+3. **Scoped patterns only — guard the identifier.** Every `rm`/remove must be anchored to a verified identifier (ticket id, worktree path, plan filename). Before using an id in a glob, assert it is **non-empty and matches `[A-Za-z0-9_-]`** — abort the whole step otherwise. An empty id collapses `…/*$id*` into `…/*` (a blanket wipe); a path-traversal or glob character escapes the intended directory. Never run a delete with an unset or unvalidated token.
+
+   ```bash
+   case "$id" in
+     ""|*[!A-Za-z0-9_-]*) echo "id missing or unsafe — skipping deletion"; return 2>/dev/null || exit 0 ;;
+   esac
+   rm -f /path/*"$id"* 2>/dev/null   # safe: $id verified non-empty and charset-clean
+   ```
+
+4. **Never touch shared or unscoped state.** Project-shared agent memory (`<PROJECT-NAME>.md`), the main checkout, the default branch, and anything not provably an orphan or a this-ticket artifact are off-limits. Scope globs so they cannot match shared files even on an empty match set.
+
+5. **Memory needs a staleness reason.** Never delete or rewrite an agent-memory entry without a drift/staleness justification from the canonical A1 Drift Classification (codebase-navigator's Memory Protocol). Re-date re-verified entries; remove only resolved/contradicted ones.
+
+6. **Preserve on failure or doubt.** If a delivery failed, or it is unclear whether an artifact is still live (a worktree with uncommitted work, a plan for an open ticket), **keep it and report it** rather than removing it. Cleanup is reversible only by not having run it.
+
+## Who follows this
+
+- **`/deliver` Phase 7 (C1)** — retires *this ticket's* artifacts on successful completion, keyed to the verified ticket id.
+- **`/improve` hygiene sweep (C2)** — finds and retires *repo-wide* orphans (abandoned worktrees, stale plans, old groom sessions, stray `/tmp` scratch, drift-stale memory), dry-run then confirmed.
+
+Both carry their own concrete guards inline (each skill runs standalone); this doc is the shared rationale they must not diverge from.

--- a/skills/improve/SKILL.md
+++ b/skills/improve/SKILL.md
@@ -50,9 +50,9 @@ Context:
 Steps:
   1. Health scorecard    [always runs]
   2. Stale work + dead code scan   [optional — yes/skip]
-  2b. Toolkit hygiene sweep        [optional — yes/skip — removes orphaned artifacts, confirmed]
-  3. Tech debt triage              [optional — yes/skip]
-  4. Retrospective                 [optional — yes/skip]
+  3. Toolkit hygiene sweep         [optional — yes/skip — removes orphaned artifacts, confirmed]
+  4. Tech debt triage              [optional — yes/skip]
+  5. Retrospective                 [optional — yes/skip]
 
 Proceed with all steps? (yes / health only / choose)
 ```
@@ -313,13 +313,18 @@ Hygiene sweep — candidates found:
 Remove these N artifacts? (yes / choose / skip)
 ```
 
-**On confirmation**, remove with the cleanup-safety guards — each pattern anchored to a verified, charset-clean identifier, never a bare glob:
+**On confirmation**, remove with the cleanup-safety guards. Every id is validated before it reaches a delete — the same guard `deliver` Phase 7 uses (cleanup-safety rule 3): skip any id that is empty or contains anything outside `[A-Za-z0-9_-]`, so a glob can never collapse to a bare wildcard:
 
 ```bash
-git worktree remove "<verified-abs-path>"            # only for confirmed-orphan trees
-git worktree prune                                   # drop stale admin entries (dirs already gone)
-rm -f ~/.claude/agent-memory/grooming-agent/plans/"<closed-ticket-id>".md
-rm -f /tmp/.deliver-"<finished-id>"-* 2>/dev/null
+# Validate an identifier before using it in any delete pattern.
+safe_id() { case "$1" in ""|*[!A-Za-z0-9_-]*) return 1 ;; *) return 0 ;; esac; }
+
+git worktree remove "<verified-abs-path>"   # confirmed-orphan trees only (refuses a dirty tree without --force)
+git worktree prune                          # drop stale admin entries for dirs already gone
+
+id="<closed-ticket-id>"; safe_id "$id" && rm -f ~/.claude/agent-memory/grooming-agent/plans/"$id".md
+id="<closed-ticket-id>"; safe_id "$id" && rm -f ~/.claude/agent-memory/grooming-agent/sessions/*"$id"* 2>/dev/null
+id="<finished-id>";      safe_id "$id" && rm -f /tmp/.deliver-"$id"-* /tmp/.improve-"$id"-* /tmp/.groom-"$id"-* 2>/dev/null
 ```
 
 Log every removal line-by-line. Anything uncertain or live is **kept and reported**, never removed.

--- a/skills/improve/SKILL.md
+++ b/skills/improve/SKILL.md
@@ -11,7 +11,7 @@ You are running the **continuous improvement cycle** — the closing ceremony of
 
 - `/improve` — full cycle
 - `/improve --health` — health scorecard only
-- `/improve --cleanup` — stale work + dead code only
+- `/improve --cleanup` — stale work + dead code + toolkit hygiene sweep only
 - `/improve --retro` — retrospective only
 
 ## When to Use
@@ -50,6 +50,7 @@ Context:
 Steps:
   1. Health scorecard    [always runs]
   2. Stale work + dead code scan   [optional — yes/skip]
+  2b. Toolkit hygiene sweep        [optional — yes/skip — removes orphaned artifacts, confirmed]
   3. Tech debt triage              [optional — yes/skip]
   4. Retrospective                 [optional — yes/skip]
 
@@ -266,6 +267,62 @@ Agent-memory duplication found:
 Do not delete anything automatically — surface findings only.
 
 **Applying accepted cleanup — worktree isolation.** `/improve` surfaces findings; it never edits on its own. When the user accepts findings and asks to apply them, and the work splits into **independent streams that mutate files in parallel** (e.g. dead-code removal, doc refresh, and debt fixes running concurrently), isolate each stream in its own git worktree per the **worktree-per-ticket convention** (`docs/guides/worktree-per-ticket.md`) — one worktree per stream, each branched off the cleanup base. Streams **merge serially** back to the base; any conflict **surfaces to the user and is never auto-resolved**. A findings-only run, a single stream, or a trivial one-file fix runs in place — **no worktree overhead**.
+
+---
+
+### Phase 3.5 — Toolkit Hygiene Sweep  *(optional)*
+
+Failed and abandoned deliveries leave **repo-wide** orphans that nothing retires: worktrees from failed deliveries, stale persisted plans, old groom sessions, drift-stale agent-memory, and stray `/tmp` scratch from toolkit runs. This sweep finds and retires them. (Per-delivery cleanup of a single ticket's artifacts is `/deliver` Phase 7, not here.)
+
+**This sweep deletes — so it follows these cleanup-safety rules** (the rules here are self-contained and authoritative; canonical rationale lives in the devexp-toolkit repo's `docs/guides/cleanup-safety.md`, a maintainer reference that is **not** installed alongside this skill — do not look for it in the current repo): dry-run and list first, confirm or log every removal, scoped patterns only (every glob anchored to a verified non-empty `[A-Za-z0-9_-]` identifier), never touch shared/unscoped state, and never prune memory without a staleness reason. Honor the skill's standing **"Never auto-delete"** stance — present the candidate list and act only on the user's confirmation (or a clear log when run under an explicit `--cleanup` confirmation).
+
+**Find candidates (read-only — list, don't delete):**
+
+```bash
+# Orphaned worktrees: registered trees whose dir is gone, or branches from failed deliveries
+git worktree list --porcelain 2>/dev/null
+git worktree prune --dry-run 2>/dev/null            # what `prune` would remove (stale admin entries)
+
+# Stale persisted plans whose ticket is already closed/delivered
+ls ~/.claude/agent-memory/grooming-agent/plans/ 2>/dev/null
+
+# Old groom sessions
+ls ~/.claude/agent-memory/grooming-agent/sessions/ 2>/dev/null
+
+# Stray /tmp scratch left by toolkit runs (list only)
+ls -1 /tmp/.deliver-* /tmp/.improve-* /tmp/.groom-* 2>/dev/null
+```
+
+For each candidate, classify before proposing removal:
+- **Orphaned worktree** → safe to remove only if its branch is merged or its delivery is abandoned (no open PR, no uncommitted work). A worktree with uncommitted work or an open ticket is **live — preserve it.**
+- **Persisted plan** → removable once its ticket is closed/delivered; keep plans for open tickets.
+- **Groom session** → removable when its ticket is closed.
+- **Agent-memory entry** → prune/refresh **only** when the canonical A1 Drift Classification flags it stale (codebase-navigator's Memory Protocol) — never on age alone.
+- **/tmp scratch** → removable if it matches a toolkit prefix and the owning run is finished.
+
+**Present the sweep report and confirm:**
+
+```
+Hygiene sweep — candidates found:
+  Orphaned worktrees:   N (branch merged/abandoned)   [live, preserved: M]
+  Stale plans:          N (ticket closed)
+  Old groom sessions:   N
+  Drift-stale memory:   N (A1 flagged)                 [kept, still current: M]
+  /tmp scratch:         N (toolkit prefix)
+
+Remove these N artifacts? (yes / choose / skip)
+```
+
+**On confirmation**, remove with the cleanup-safety guards — each pattern anchored to a verified, charset-clean identifier, never a bare glob:
+
+```bash
+git worktree remove "<verified-abs-path>"            # only for confirmed-orphan trees
+git worktree prune                                   # drop stale admin entries (dirs already gone)
+rm -f ~/.claude/agent-memory/grooming-agent/plans/"<closed-ticket-id>".md
+rm -f /tmp/.deliver-"<finished-id>"-* 2>/dev/null
+```
+
+Log every removal line-by-line. Anything uncertain or live is **kept and reported**, never removed.
 
 ---
 


### PR DESCRIPTION
Closes #40 · part of #32 · depends on #35 (A3) + #36 (B1). **Final ticket of the epic.**

## What
Failed/abandoned deliveries leave repo-wide orphans that nothing retires. Adds **Phase 3.5 — Toolkit Hygiene Sweep** to `/improve`: finds and retires orphaned worktrees, stale persisted plans, old groom sessions, drift-stale agent-memory, and stray `/tmp` toolkit scratch.

## Safety model (this is the broad-deletion ticket — built safety-first)
- **Dry-run then confirm.** Candidate-finding is **read-only** (`git worktree list`, `prune --dry-run`, `ls`); nothing is deleted before the user sees the report. Honors improve's standing **"Never auto-delete"** stance.
- **Guarded deletes only after confirmation**, each anchored to a verified non-empty `[A-Za-z0-9_-]` identifier — never a bare glob.
- **Memory** pruned only when the canonical **A1 Drift Classification** flags it stale — never on age.
- **Live/uncertain artifacts** (worktree with uncommitted work, plan for an open ticket) are **kept and reported**.

## New shared doc
`docs/guides/cleanup-safety.md` — canonical deletion-safety rationale shared by deliver C1 (#39) and improve C2. Indexed in `docs/README.md`, `docs/guides/README.md`, and the CLAUDE.md doc table.

## Install-model note (per your question)
`devexp install` deploys `agents/skills/hooks/mcps` but **not `docs/`** (`cli/internal/assets/assets.go` `//go:embed`). So the sweep states its safety rules **inline and self-contained** in the SKILL.md (what actually travels/enforces), and labels `cleanup-safety.md` explicitly as a **maintainer-only reference** that won't exist in a user's repo — no dangling local link.

## Acceptance Criteria
- [x] Hygiene sweep finds + removes orphaned worktrees, stale plans, old groom sessions, stray /tmp scratch
- [x] Prunes/refreshes agent-memory only when A1 drift flags it stale
- [x] Reports what it removed; destructive actions confirmed or clearly logged
- [x] Never deletes memory without a drift/staleness reason
- [x] Tests — structural + read-only-find-block verification (see note)

## Non-Goal honored
Per-delivery cleanup of a single ticket's artifacts is C1/#39 — explicitly out of scope; this sweep is repo-wide orphans.

## Note on "tests"
Skill/doc-prose change, no executable unit. Verified: all AC behaviors present, find block proven read-only (no rm/remove until the confirmation block), safety guards inline. No Go code touched; CLI suite stays green.

Follow-up (separate small PR): relabel the pre-existing `worktree-per-ticket.md` references in deliver/improve (from #37/#38) as maintainer-only too, for consistency.

Delivered via worktree `feat/40-hygiene-sweep`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)