### PR TITLE
#51: label toolkit-internal doc references as maintainer-only

### DIFF
--- a/skills/deliver/SKILL.md
+++ b/skills/deliver/SKILL.md
@@ -107,7 +107,7 @@ Wait for confirmation. The user can stop at any step.
 
 ### Phase 1.5 — Isolate the Ticket in a Worktree
 
-Before implementing, isolate this ticket's work in its own git worktree. This follows the **worktree-per-ticket convention** documented in `docs/guides/worktree-per-ticket.md` (devexp-toolkit) — that doc is the single source of truth for the trigger, naming scheme, lifecycle, and merge discipline summarized here. Phases 2–5 (implement, instrument, test, review) all run **inside** this worktree; the main checkout is never mutated during delivery.
+Before implementing, isolate this ticket's work in its own git worktree. The trigger, naming scheme, lifecycle, and merge discipline are all summarized inline below — this skill is self-contained. (The canonical rationale lives in `docs/guides/worktree-per-ticket.md`, a maintainer reference in the devexp-toolkit repo that is **not** installed alongside this skill — don't look for it in the current repo.) Phases 2–5 (implement, instrument, test, review) all run **inside** this worktree; the main checkout is never mutated during delivery.
 
 **Create the worktree** on a fresh branch derived from the ticket id — branch `<type>/<ticket-id>`, directory a sibling of the main checkout so it is never scanned or committed into the primary tree:
 
@@ -454,4 +454,4 @@ Next:
 - **Release is the only hard gate** — every other step can be skipped; release requires explicit confirmation because it's irreversible and affects shared systems
 - **Architecture check is a suggestion, not a gate** — surface it for high-complexity tickets; never block on it
 - **Test coverage, not test count** — if the implementation agent wrote tests, verify they cover the acceptance criteria, not just that they exist
-- **Worktree isolation is the default, merge is deferred** — each ticket is delivered in its own worktree (`docs/guides/worktree-per-ticket.md`); the branch merges only at the release gate, and conflicts always surface to the user — never auto-resolve them
+- **Worktree isolation is the default, merge is deferred** — each ticket is delivered in its own worktree (rationale: `docs/guides/worktree-per-ticket.md`, maintainer-only in the devexp-toolkit repo, not installed); the branch merges only at the release gate, and conflicts always surface to the user — never auto-resolve them

--- a/skills/improve/SKILL.md
+++ b/skills/improve/SKILL.md
@@ -246,7 +246,7 @@ ls ~/.claude/agent-memory/graphify-out/graph.json 2>/dev/null && echo "graph: EX
 
 If the graph exists: run `/graphify ~/.claude/agent-memory --update` to refresh it, then read the `## Surprising Connections` section of `~/.claude/agent-memory/graphify-out/GRAPH_REPORT.md`. Each cross-agent reference there is a candidate for consolidation into a shared atlas (`codebase-navigator/<project>.md`) instead of duplication per-agent.
 
-If the graph doesn't exist: note it as a one-time optional setup step — see [Cross-Agent Duplication Mapping](../../docs/development/agent-architecture-reference.md#cross-agent-duplication-mapping). Don't build it on `/improve`'s own initiative; the first run is user-directed.
+If the graph doesn't exist: note it as a one-time optional setup step (the "Cross-Agent Duplication Mapping" section of `docs/development/agent-architecture-reference.md` — a maintainer-only doc in the devexp-toolkit repo, not installed alongside this skill). Don't build it on `/improve`'s own initiative; the first run is user-directed.
 
 Present findings as a cleanup checklist:
 ```
@@ -266,7 +266,7 @@ Agent-memory duplication found:
 
 Do not delete anything automatically — surface findings only.
 
-**Applying accepted cleanup — worktree isolation.** `/improve` surfaces findings; it never edits on its own. When the user accepts findings and asks to apply them, and the work splits into **independent streams that mutate files in parallel** (e.g. dead-code removal, doc refresh, and debt fixes running concurrently), isolate each stream in its own git worktree per the **worktree-per-ticket convention** (`docs/guides/worktree-per-ticket.md`) — one worktree per stream, each branched off the cleanup base. Streams **merge serially** back to the base; any conflict **surfaces to the user and is never auto-resolved**. A findings-only run, a single stream, or a trivial one-file fix runs in place — **no worktree overhead**.
+**Applying accepted cleanup — worktree isolation.** `/improve` surfaces findings; it never edits on its own. When the user accepts findings and asks to apply them, and the work splits into **independent streams that mutate files in parallel** (e.g. dead-code removal, doc refresh, and debt fixes running concurrently), isolate each stream in its own git worktree per the **worktree-per-ticket convention** (rationale: `docs/guides/worktree-per-ticket.md`, a maintainer-only doc in the devexp-toolkit repo, not installed alongside this skill) — one worktree per stream, each branched off the cleanup base. Streams **merge serially** back to the base; any conflict **surfaces to the user and is never auto-resolved**. A findings-only run, a single stream, or a trivial one-file fix runs in place — **no worktree overhead**.
 
 ---
 
@@ -410,7 +410,7 @@ Next cycle:
 
 - **Health always runs** — it's the minimum viable maintenance action; everything else is optional
 - **Never auto-delete** — stale work and dead code scans produce findings for human review, not automated removal
-- **Isolate parallel cleanup in worktrees** — when applying accepted findings across independent streams concurrently, each stream gets its own worktree ([`docs/guides/worktree-per-ticket.md`](../../docs/guides/worktree-per-ticket.md)), merged serially with conflicts surfaced to the user; findings-only and single-stream runs stay in place with no overhead
+- **Isolate parallel cleanup in worktrees** — when applying accepted findings across independent streams concurrently, each stream gets its own worktree (rationale: `docs/guides/worktree-per-ticket.md`, maintainer-only in the devexp-toolkit repo, not installed), merged serially with conflicts surfaced to the user; findings-only and single-stream runs stay in place with no overhead
 - **CI failure pre-empts everything** — a failing pipeline invalidates the health scorecard's CI dimension; address it first
 - **Retrospective items need evidence** — if you can't point to a git commit, health metric, or incident, the item is a feeling, not a finding
 - **Trend direction matters more than absolute score** — a project with 65% coverage improving (↑) is in better shape than one at 80% degrading (↓)


### PR DESCRIPTION
Closes #51 · sub-issue of #32 · follow-up to #37/#38/#40.

## What
`devexp install` deploys `agents/skills/hooks/mcps` but **not `docs/`**, so in-skill references to the toolkit's own `docs/` files dangle in a user's repo. This relabels every such reference in `deliver` + `improve` as maintainer-only (matching the wording #40 introduced for `cleanup-safety.md`) and removes the broken relative markdown links.

## Changes (wording only)
- `skills/deliver/SKILL.md` — 2 worktree-per-ticket refs (Phase 1.5 + Guidelines)
- `skills/improve/SKILL.md` — 2 worktree-per-ticket refs + 1 pre-existing `agent-architecture-reference.md` ref (same class, in scope per the ticket title)

Each now reads "rationale: `<doc>`, a maintainer-only doc in the devexp-toolkit repo, not installed alongside this skill." The worktree/cleanup rules remain stated **inline**, so the skills stay self-sufficient — enforcement unchanged.

## Acceptance Criteria
- [x] Reword each toolkit-internal `docs/` reference in deliver/improve as maintainer-only
- [x] Worktree lifecycle rules remain stated inline (self-sufficient without the doc)
- [x] No behavior change; wording only — 0 dangling relative md-links remain (verified)

## Non-Goal
Shipping `docs/` via install — explicitly decided against (docs don't enforce; inline rules + the dangerous-cmd-guard hook are the enforcement layers).

Review: trivial prose relabel, no logic/commands — verified mechanically (no dangling links, inline rules intact); full review agent skipped.

Delivered via worktree `docs/51-maintainer-ref-labels`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)