### PR TITLE
#59: persist /monitor report + reconcile with /improve Observability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ cli/internal/assets/devexp.config.json
 cli/internal/assets/uninstall.sh
 graphify-out/
 .devexp/health-baseline.json
+.devexp/system-health-review.md

--- a/skills/improve/SKILL.md
+++ b/skills/improve/SKILL.md
@@ -124,6 +124,16 @@ If no infrastructure definitions are found: mark as N/A.
 Thresholds: 🟢 variables documented, no inline secrets, versioning/locking present · 🟡 partial (some undocumented vars or missing lock) · 🔴 inline secrets found or no documentation at all
 
 **Observability Maturity:**
+
+There is one home for the deep "is the deployed system healthy?" review — `/monitor`. If it has run, reuse its result instead of re-deriving:
+
+```bash
+# Prefer /monitor's persisted review if present — it's the authoritative deep assessment
+cat .devexp/system-health-review.md 2>/dev/null | head -40
+```
+
+If `.devexp/system-health-review.md` exists, take this dimension's status from its overall band and cite the review (note its date), pointing the reader to `/monitor` for the full breakdown — do not recompute. If it is absent, fall back to the lightweight repo-signal check below, and suggest running `/monitor` for the deep assessment (don't attempt a deep review here — that's `/monitor`'s job):
+
 ```bash
 # Check for SLO/SLI documentation
 find . -maxdepth 4 \( -name "slo.md" -o -name "slos.md" -o -name "sli.md" -o -name "runbook*" \) 2>/dev/null | grep -v ".git" | head -5

--- a/skills/monitor/SKILL.md
+++ b/skills/monitor/SKILL.md
@@ -14,7 +14,7 @@ This is a **point-in-time review**, not a runtime daemon: it inspects what exist
 - `/monitor` — review every deployed-system surface detected in this repo/environment
 - `/monitor <surface>` — scope the review to a single detected surface (e.g. the cloud surface, the dashboards surface, the logging surface)
 
-Invoked directly by the user. `/monitor` is self-contained — it does not call other skills, and other skills do not call it. (`/improve`'s Observability Maturity dimension defers to this skill for the deep review — see #59 — but that is a documentation pointer, not a runtime dependency.)
+Invoked directly by the user. `/monitor` is self-contained — it does not call other skills, and other skills do not call it. (`/improve`'s Observability Maturity dimension *defers* to this skill for the deep review by reading the persisted `.devexp/system-health-review.md` if present — a one-way artifact handoff, not a runtime dependency.)
 
 ## When to Use
 
@@ -26,7 +26,7 @@ Do **not** use it to assess code quality, test coverage, or repo hygiene — tha
 
 ## Process
 
-> **Status.** The full review pipeline is live: scope handling (Phase 0), surface detection (Phase 1), per-surface review (Phase 2), and scoring (Phase 3) all produce real output. Remaining epic #54 work is non-blocking: persisting the report to `.devexp/system-health-review.md` and reconciling with `/improve`'s Observability dimension (#59), and documenting `/monitor` as a first-class orchestrator (#60).
+> **Status.** The full pipeline is live: scope handling (Phase 0), surface detection (Phase 1), per-surface review (Phase 2), scoring (Phase 3), report (Phase 4), and persistence (Phase 5) all produce real output. Remaining epic #54 work is non-blocking: documenting `/monitor` as a first-class orchestrator (#60).
 
 ### Phase 0 — Establish Scope
 
@@ -187,7 +187,23 @@ Anomalies / blind spots:
   - <actionable item with evidence>
 ```
 
-Persisting this report to `.devexp/system-health-review.md` and reconciling with `/improve`'s Observability dimension is handled in #59.
+### Phase 5 — Persist
+
+Write the rendered report (the Phase 4 block) to `.devexp/system-health-review.md`, overwriting any previous run — it is a current-state snapshot, not an append log. This is the artifact `/improve` reads to avoid re-deriving system health.
+
+```bash
+mkdir -p .devexp
+# write the report to .devexp/system-health-review.md (overwrite)
+```
+
+Ensure the artifact is git-ignored — it is a local snapshot, not source. The existing ignore entry targets the baseline *file* (`.devexp/health-baseline.json`), not the `.devexp/` directory, so the review needs its **own** line:
+
+```bash
+grep -qxF '.devexp/system-health-review.md' .gitignore 2>/dev/null \
+  || printf '%s\n' '.devexp/system-health-review.md' >> .gitignore
+```
+
+**Trend continuity (optional).** If `.devexp/health-baseline.json` exists, update its existing `observability` key with this run's overall band so `/improve` can show a trend — honor the current schema, do not migrate it or add new top-level keys. If the baseline is absent, do not create one; `/monitor` does not own that file.
 
 ---
 


### PR DESCRIPTION
Part of epic #54. Closes #59. Targets `main` (#58 merged).

Persists `/monitor`'s scored report and gives the toolkit **one home** for "is the deployed system healthy?"

## What's implemented
- **`/monitor` Phase 5 (Persist)** — writes the rendered report to `.devexp/system-health-review.md` (overwrite; it's a current-state snapshot, not a log), self-adds its own `.gitignore` line, and optionally updates the baseline's existing `observability` key for trend continuity
- **`.gitignore`** — `.devexp/system-health-review.md` added as its **own** line (the existing entry targets the baseline *file* `.devexp/health-baseline.json`, not the `.devexp/` dir)
- **`/improve` reconciliation** — Observability Maturity now *defers* to `/monitor`: if the persisted review exists it reuses that band and cites it (pointing to `/monitor` for the breakdown); otherwise it stays the lightweight repo-signal check and suggests running `/monitor`. No two divergent deep reviews.
- **No schema migration** — the baseline's existing `observability` key is honored; no new top-level keys, no baseline created if absent

## Verification
All 4 ACs confirmed by scan; stale "handled in #59" deferral removed; re-staged into installer asset set; `go test ./internal/skills/...` green.

## Epic status after this
Only **#60** (document `/monitor` as the 5th orchestrator) remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)