### PR TITLE
#60: document /monitor as the 5th orchestrator

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 A curated collection of Claude Code agents, skills, hooks, and MCP servers that brings a consistent, expert-level development experience to any project. Install once, distribute to your team.
 
-**Components**: `agents/` (34 agents) · `skills/` (5 user commands) · `hooks/` (10 safety guards) · `mcps/` (MCP registry)
+**Components**: `agents/` (34 agents) · `skills/` (6 user commands) · `hooks/` (10 safety guards) · `mcps/` (MCP registry)
 
 > New to a repo? Run `/devxp` first — it orients on the codebase, ensures `CLAUDE.md` and `docs/` exist or are current, and routes you to the right skill next.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A curated collection of Claude Code agents, skills, and MCP servers that bring a consistent, expert-level development experience to any project.
 
-Install once. Get autonomous bug fixes, expert code review, codebase navigation, execution tracing, and security audits — all driven by four commands that cover the full development lifecycle.
+Install once. Get autonomous bug fixes, expert code review, codebase navigation, execution tracing, and security audits — all driven by five commands that cover the full development lifecycle.
 
 ---
 
@@ -13,7 +13,7 @@ Install once. Get autonomous bug fixes, expert code review, codebase navigation,
 curl -fsSL https://raw.githubusercontent.com/alexandrocuma/devexp-toolkit/main/scripts/remote-install.sh | bash
 ```
 
-Then use four commands to cover the full development cycle:
+Then use these commands to cover the full development cycle:
 
 | Command | When |
 |---------|------|
@@ -21,9 +21,11 @@ Then use four commands to cover the full development cycle:
 | `/refine` | Turn an idea into a groomed, ready-to-build ticket |
 | `/deliver <ticket>` | Implement, test, review, and release a ticket |
 | `/improve` | Sprint end — health scorecard, cleanup, debt triage, retro |
+| `/monitor [<surface>]` | Operate — review the deployed system's health, scored, anytime |
 
 ```
 /devxp  →  /refine  →  /deliver  →  /improve  →  next sprint
+                                  /monitor  →  review the deployed system, anytime
 ```
 
 → Full walkthrough: [docs/guides/quickstart.md](docs/guides/quickstart.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@ How-to guides for using and configuring the framework.
 
 | Doc | Description |
 |-----|-------------|
-| [Quick Start](guides/quickstart.md) | Zero to shipped — install, then use the 5 commands end-to-end |
+| [Quick Start](guides/quickstart.md) | Zero to shipped — install, then use the 6 commands end-to-end |
 | [Docs Architecture](guides/docs-architecture.md) | CLAUDE.md-as-indexer pattern + standard docs/ folder tree — apply this in every project |
 | [Install & Services](guides/install.md) | install.sh flags, start-services.sh, uninstall.sh, and CLI installation paths |
 | [Team Distribution](guides/team-distribution.md) | Fork and customise devexp for your organisation via devexp.config.json |

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -6,7 +6,7 @@ How-to guides for using, configuring, and understanding the devexp framework.
 
 | File | Description | Status |
 |------|-------------|--------|
-| [quickstart.md](quickstart.md) | Zero to shipped — install, then use the 4 orchestrators to orient, refine, deliver, and improve | ready |
+| [quickstart.md](quickstart.md) | Zero to shipped — install, then use the 5 orchestrators to orient, refine, deliver, improve, and monitor | ready |
 | [docs-architecture.md](docs-architecture.md) | CLAUDE.md-as-indexer pattern + standard docs/ folder tree — apply this in every project | ready |
 | [install.md](install.md) | install.sh, start-services.sh, uninstall.sh — flags, behavior, CLI paths | ready |
 | [team-distribution.md](team-distribution.md) | Forking and customizing devexp for your organisation via devexp.config.json | ready |

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -1,6 +1,6 @@
 # Quick Start
 
-Everything you need to go from zero to shipping — using only four commands.
+Everything you need to go from zero to shipping — plus `/monitor` to review what's deployed.
 
 ---
 
@@ -102,11 +102,13 @@ All diagnostic steps run inline — nothing is deleted automatically. You get fi
 
 ```
 /devxp  ──→  /refine  ──→  /deliver  ──→  /improve
-  ↑                                            │
-  └──────────────── next sprint ───────────────┘
+  ↑                              │             │
+  └─────────── next sprint ──────┴─────────────┘
+                                 │
+                            /monitor   (operate: review the deployed system, anytime)
 ```
 
-This is the full development cycle. Most work fits entirely within these four commands.
+This is the full development cycle. The four build commands carry most work; `/monitor` is the operate phase — run it anytime to review the health of what's deployed, independent of any code change.
 
 ---
 

--- a/docs/reference/skills.md
+++ b/docs/reference/skills.md
@@ -1,8 +1,8 @@
 # Skills Reference
 
-## The Five Commands
+## The Six Commands
 
-The entire development lifecycle runs through five slash commands. Type `/` in Claude Code and you'll see exactly these:
+The development lifecycle runs through six slash commands — five lifecycle orchestrators plus the `/graphify` utility. Type `/` in Claude Code and you'll see exactly these:
 
 | Command | When to use |
 |---------|-------------|
@@ -10,13 +10,18 @@ The entire development lifecycle runs through five slash commands. Type `/` in C
 | `/refine` | Turn an idea or request into a groomed, ready-to-build ticket |
 | `/deliver <ticket>` | Implement, test, review, and release a ticket end-to-end |
 | `/improve` | Sprint end or maintenance window — health, cleanup, debt, retro |
+| `/monitor [<surface>]` | Operate phase — review the deployed system's health (telemetry/config), scored, anytime |
 | `/graphify` | Build a persistent knowledge graph from this codebase |
 
 ```
 /devxp  →  /refine  →  /deliver  →  /improve
-  ↑                                      |
-  └──────────── next sprint ─────────────┘
+  ↑                          │           │
+  └──────── next sprint ─────┴───────────┘
+                             │
+                        /monitor   (operate: review the deployed system, anytime)
 ```
+
+The first four orchestrators *build* software; `/monitor` *operates* what's shipped — a change-independent health read that does not diff commits.
 
 ---
 
@@ -48,6 +53,14 @@ The entire development lifecycle runs through five slash commands. Type `/` in C
 - **Phase 3:** Stale work (orphaned branches, old PRs, zombie flags), dead code (unused exports, orphaned files), convention audit (competing patterns)
 - **Phase 4:** Tech debt triage via `tech-debt` agent — business-prioritized with ROI
 - **Phase 5:** Sprint retrospective — evidence-grounded Start/Stop/Continue findings
+
+### `/monitor [<surface>]`
+- **Operate phase** — assesses the *deployed* system, not the codebase; change-independent (never diffs commits), runnable anytime
+- **Phase 1:** Detects deployed-system surfaces by category — cloud/infra, dashboards, logging, alerting, tracing/metrics — from repo signals and already-authenticated connectors; vendor-agnostic
+- **Phase 2:** Reviews each surface live (read-only connector query) or via config-as-code fallback; labels findings `[live]`/`[config]`; cross-references observability coverage against critical paths (covered/partial/blind)
+- **Phase 3:** Per-surface 🟢/🟡/🔴/N/A + an equal-weighted composite score, plus a ranked, actionable anomaly list with evidence
+- **Phase 5:** Persists the scored report to `.devexp/system-health-review.md`. `/improve`'s Observability Maturity dimension defers to this artifact when present — one home for "is the system healthy?"
+- `/monitor <surface>` scopes the review to a single detected surface
 
 ### `/graphify`
 - Builds a persistent knowledge graph from the codebase

--- a/skills/README.md
+++ b/skills/README.md
@@ -6,9 +6,9 @@ Install them by running `../install.sh` from the repo root. Installed skills lan
 
 ---
 
-## The Five Commands
+## The Six Commands
 
-These five orchestrators are the entire user-facing surface. Everything else — ~30 specialist capabilities — runs as agents (`agents/<name>.md`) or inline within these orchestrators.
+These six commands are the entire user-facing surface — five lifecycle orchestrators plus the `/graphify` utility. Everything else — ~30 specialist capabilities — runs as agents (`agents/<name>.md`) or inline within these orchestrators.
 
 | Directory | Slash Command | When to use |
 |-----------|---------------|------------|
@@ -16,12 +16,15 @@ These five orchestrators are the entire user-facing surface. Everything else —
 | `refine/` | `/refine` | You have an idea or feature request to turn into a groomed ticket |
 | `deliver/` | `/deliver <ticket>` | You have a groomed ticket and want to build and ship it |
 | `improve/` | `/improve` | Sprint end or maintenance window — health, cleanup, retrospective |
+| `monitor/` | `/monitor [<surface>]` | Operate phase — review the deployed system's health via telemetry/config, anytime |
 | `graphify/` | `/graphify` | Build a persistent, queryable knowledge graph from this codebase |
 
 ```
 /devxp  →  /refine  →  /deliver  →  /improve
-  ↑                                      |
-  └──────────── next sprint ─────────────┘
+  ↑                          │           │
+  └──────── next sprint ─────┴───────────┘
+                             │
+                        /monitor   (operate: review the deployed system, anytime)
 ```
 
 ---


### PR DESCRIPTION
Part of epic #54. **Closes #60 and completes the epic** (#55–#60 all delivered).

Surfaces `/monitor` everywhere the toolkit advertises its command set, and reframes the counts (5 commands → 6; 4 orchestrators → 5 lifecycle orchestrators + the `/graphify` utility).

## Files updated (live surface docs)
- **`docs/reference/skills.md`** — "The Six Commands" table + flow diagram + full "What `/monitor` does" phase breakdown
- **`skills/README.md`** — "The Six Commands" table + flow
- **`CLAUDE.md`** — `skills/` count 5 → 6 user commands
- **`README.md`** — command table + intro ("five commands") + flow
- **`docs/README.md`**, **`docs/guides/README.md`**, **`docs/guides/quickstart.md`** — count + flow + `/monitor` mention

## Intentionally NOT touched
- **`CHANGELOG.md`** — a historical release entry; editing shipped history is wrong. `/monitor` gets its own changelog entry when the epic is released.
- **`docs/coverage.md`** — a dated generated snapshot, not a live surface advertisement.
- **`34 agents`** counts — unrelated to the orchestrator command surface.

## Verification
- Stale-ref scan of live docs clean ("first four orchestrators *build*" retained — accurate)
- `/monitor` deploys: confirmed via installer asset staging (`./install.sh` is an interactive TUI, so verified through the same staging path the installer consumes); `go test ./internal/skills/...` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)