### PR TITLE
#67: unit-test the install/mcp/ui layer (0% → 83/65/62%)

### DIFF
--- a/cli/internal/assets/assets_test.go
+++ b/cli/internal/assets/assets_test.go
@@ -1,0 +1,111 @@
+package assets
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestExtractFile(t *testing.T) {
+	tests := map[string]struct {
+		src       string
+		destRel   string
+		perm      os.FileMode
+		wantErr   bool
+		wantWrite bool
+	}{
+		"writes contents + perm, creates parent dirs": {
+			src:       "uninstall.sh",
+			destRel:   filepath.Join("nested", "deeper", "uninstall.sh"),
+			perm:      0o755,
+			wantErr:   false,
+			wantWrite: true,
+		},
+		"missing source returns error, no partial write": {
+			src:       "does-not-exist.sh",
+			destRel:   filepath.Join("nested", "missing.sh"),
+			perm:      0o644,
+			wantErr:   true,
+			wantWrite: false,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			dest := filepath.Join(t.TempDir(), tt.destRel)
+
+			err := ExtractFile(FS, tt.src, dest, tt.perm)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+			} else if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			info, statErr := os.Stat(dest)
+			if !tt.wantWrite {
+				if !os.IsNotExist(statErr) {
+					t.Fatalf("expected dest to not exist, stat err = %v", statErr)
+				}
+				return
+			}
+
+			if statErr != nil {
+				t.Fatalf("expected dest written, stat err = %v", statErr)
+			}
+
+			want, readErr := fs.ReadFile(FS, tt.src)
+			if readErr != nil {
+				t.Fatalf("reading embedded source: %v", readErr)
+			}
+			got, readErr := os.ReadFile(dest)
+			if readErr != nil {
+				t.Fatalf("reading dest: %v", readErr)
+			}
+			if string(got) != string(want) {
+				t.Errorf("content mismatch: dest has %d bytes, source has %d bytes", len(got), len(want))
+			}
+
+			if perm := info.Mode().Perm(); perm != tt.perm {
+				t.Errorf("perm = %o, want %o", perm, tt.perm)
+			}
+		})
+	}
+}
+
+func TestEmbeddedFS(t *testing.T) {
+	tests := map[string]struct {
+		path  string
+		isDir bool
+	}{
+		"agents dir":         {path: "agents", isDir: true},
+		"skills dir":         {path: "skills", isDir: true},
+		"hooks dir":          {path: "hooks", isDir: true},
+		"mcps dir":           {path: "mcps", isDir: true},
+		"devexp.config.json": {path: "devexp.config.json", isDir: false},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			info, err := fs.Stat(FS, tt.path)
+			if err != nil {
+				t.Fatalf("fs.Stat(%q): %v", tt.path, err)
+			}
+			if info.IsDir() != tt.isDir {
+				t.Errorf("%q IsDir() = %v, want %v", tt.path, info.IsDir(), tt.isDir)
+			}
+			if tt.isDir {
+				entries, err := fs.ReadDir(FS, tt.path)
+				if err != nil {
+					t.Fatalf("fs.ReadDir(%q): %v", tt.path, err)
+				}
+				if len(entries) == 0 {
+					t.Errorf("%q is empty", tt.path)
+				}
+			}
+		})
+	}
+}

--- a/cli/internal/mcp/mcp_test.go
+++ b/cli/internal/mcp/mcp_test.go
@@ -175,6 +175,7 @@ func captureStdout(t *testing.T, fn func()) string {
 		t.Fatalf("os.Pipe: %v", err)
 	}
 	os.Stdout = w
+	defer func() { os.Stdout = orig }()
 
 	done := make(chan string)
 	go func() {
@@ -194,7 +195,6 @@ func captureStdout(t *testing.T, fn func()) string {
 
 	fn()
 	_ = w.Close()
-	os.Stdout = orig
 	return <-done
 }
 
@@ -275,13 +275,14 @@ func TestInstallOpencode(t *testing.T) {
 	}
 
 	tests := map[string]struct {
-		seed       func(path string) // optional pre-existing config
-		mcps       []MCP             // override; nil uses the default stdio my-server
-		env        map[string]string // override; nil uses empty env
-		dryRun     bool
-		reinstall  bool
-		wantNoFile bool
-		assert     func(t *testing.T, config map[string]interface{})
+		seed          func(path string) // optional pre-existing config
+		mcps          []MCP             // override; nil uses the default stdio my-server
+		env           map[string]string // override; nil uses empty env
+		dryRun        bool
+		reinstall     bool
+		wantNoFile    bool
+		wantUnchanged bool // file must be byte-for-byte identical to the seed
+		assert        func(t *testing.T, config map[string]interface{})
 	}{
 		"fresh write creates config with mcp entry": {
 			assert: func(t *testing.T, config map[string]interface{}) {
@@ -324,6 +325,7 @@ func TestInstallOpencode(t *testing.T) {
 			},
 		},
 		"merge identical entry skips, no rewrite": {
+			wantUnchanged: true,
 			seed: func(path string) {
 				seed := map[string]interface{}{
 					"mcp": map[string]interface{}{
@@ -435,11 +437,9 @@ func TestInstallOpencode(t *testing.T) {
 				t.Fatalf("config not written: %v", readErr)
 			}
 
-			// "identical entry skips" should leave the file byte-for-byte unchanged.
-			if name == "merge identical entry skips, no rewrite" && beforeBytes != nil {
-				if string(data) != string(beforeBytes) {
-					t.Errorf("file was rewritten despite identical entry")
-				}
+			// A skip path must leave the file byte-for-byte unchanged.
+			if tt.wantUnchanged && string(data) != string(beforeBytes) {
+				t.Errorf("file was rewritten despite identical entry")
 			}
 
 			var config map[string]interface{}

--- a/cli/internal/mcp/mcp_test.go
+++ b/cli/internal/mcp/mcp_test.go
@@ -1,0 +1,454 @@
+package mcp
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestResolveStr(t *testing.T) {
+	tests := map[string]struct {
+		in   string
+		env  map[string]string
+		want string
+	}{
+		"single var substituted":      {in: "${TOKEN}", env: map[string]string{"TOKEN": "abc"}, want: "abc"},
+		"unknown var becomes empty":   {in: "${MISSING}", env: map[string]string{}, want: ""},
+		"literal only unchanged":      {in: "no-vars-here", env: map[string]string{"X": "y"}, want: "no-vars-here"},
+		"multiple vars in one string": {in: "${A}-${B}", env: map[string]string{"A": "1", "B": "2"}, want: "1-2"},
+		"var embedded in literal":     {in: "pre-${V}-post", env: map[string]string{"V": "mid"}, want: "pre-mid-post"},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			if got := resolveStr(tt.in, tt.env); got != tt.want {
+				t.Errorf("resolveStr(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTransport(t *testing.T) {
+	tests := map[string]struct {
+		transport string
+		want      string
+	}{
+		"empty defaults to stdio": {transport: "", want: "stdio"},
+		"http honored":            {transport: "http", want: "http"},
+		"sse honored":             {transport: "sse", want: "sse"},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			m := MCP{Transport: tt.transport}
+			if got := m.transport(); got != tt.want {
+				t.Errorf("transport() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestScope(t *testing.T) {
+	tests := map[string]struct {
+		scope string
+		want  string
+	}{
+		"empty defaults to user": {scope: "", want: "user"},
+		"local honored":          {scope: "local", want: "local"},
+		"project honored":        {scope: "project", want: "project"},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			m := MCP{Scope: tt.scope}
+			if got := m.scope(); got != tt.want {
+				t.Errorf("scope() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLoadRegistry(t *testing.T) {
+	tests := map[string]struct {
+		content   string
+		writeFile bool
+		wantErr   bool
+		wantLen   int
+	}{
+		"valid JSON array parsed": {
+			content:   `[{"name":"a","command":"cmd-a"},{"name":"b","command":"cmd-b"}]`,
+			writeFile: true,
+			wantErr:   false,
+			wantLen:   2,
+		},
+		"malformed JSON errors": {
+			content:   `[{"name":`,
+			writeFile: true,
+			wantErr:   true,
+		},
+		"missing file errors": {
+			writeFile: false,
+			wantErr:   true,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "registry.json")
+			if tt.writeFile {
+				if err := os.WriteFile(path, []byte(tt.content), 0o644); err != nil {
+					t.Fatalf("writing fixture: %v", err)
+				}
+			}
+
+			mcps, err := LoadRegistry(path)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(mcps) != tt.wantLen {
+				t.Errorf("len = %d, want %d", len(mcps), tt.wantLen)
+			}
+		})
+	}
+}
+
+func TestLoadFromRaw(t *testing.T) {
+	tests := map[string]struct {
+		raw     json.RawMessage
+		wantErr bool
+		wantNil bool
+		wantLen int
+	}{
+		"empty raw returns nil,nil": {
+			raw:     json.RawMessage{},
+			wantNil: true,
+		},
+		"valid raw parsed": {
+			raw:     json.RawMessage(`[{"name":"a"}]`),
+			wantLen: 1,
+		},
+		"malformed raw errors": {
+			raw:     json.RawMessage(`[{`),
+			wantErr: true,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			mcps, err := LoadFromRaw(tt.raw)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.wantNil {
+				if mcps != nil {
+					t.Errorf("expected nil slice, got %v", mcps)
+				}
+				return
+			}
+			if len(mcps) != tt.wantLen {
+				t.Errorf("len = %d, want %d", len(mcps), tt.wantLen)
+			}
+		})
+	}
+}
+
+// captureStdout swaps os.Stdout for a pipe, runs fn, and returns whatever was printed.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stdout = w
+
+	done := make(chan string)
+	go func() {
+		var sb strings.Builder
+		buf := make([]byte, 4096)
+		for {
+			n, err := r.Read(buf)
+			if n > 0 {
+				sb.Write(buf[:n])
+			}
+			if err != nil {
+				break
+			}
+		}
+		done <- sb.String()
+	}()
+
+	fn()
+	_ = w.Close()
+	os.Stdout = orig
+	return <-done
+}
+
+func TestAddClaude_NonExec(t *testing.T) {
+	tests := map[string]struct {
+		mcp      MCP
+		env      map[string]string
+		dryRun   bool
+		contains []string
+	}{
+		"missing required env returns nil, prints REQUIRED, no exec": {
+			mcp:      MCP{Name: "needs-token", RequiredEnv: []string{"API_TOKEN"}},
+			env:      map[string]string{},
+			dryRun:   false,
+			contains: []string{"[REQUIRED]", "API_TOKEN"},
+		},
+		"dry-run stdio prints claude mcp add -- command": {
+			mcp:      MCP{Name: "local-server", Command: "node", Args: []string{"server.js"}},
+			env:      map[string]string{},
+			dryRun:   true,
+			contains: []string{"[dry-run]", "claude mcp add --scope user", "node", "server.js"},
+		},
+		"dry-run http prints --transport": {
+			mcp:      MCP{Name: "remote-server", Transport: "http", URL: "https://example.com/mcp"},
+			env:      map[string]string{},
+			dryRun:   true,
+			contains: []string{"[dry-run]", "--transport http", "https://example.com/mcp"},
+		},
+		"missing env with setup instructions prints guidance": {
+			mcp: MCP{
+				Name:              "gated",
+				Env:               map[string]string{"BASE": "default"},
+				RequiredEnv:       []string{"SECRET"},
+				SetupInstructions: "export SECRET=...\nget it from the dashboard",
+			},
+			env:      map[string]string{"BASE": "override"},
+			dryRun:   false,
+			contains: []string{"[REQUIRED]", "SECRET", "get it from the dashboard", "gated will not be available"},
+		},
+		"dry-run stdio resolves env-var args": {
+			mcp: MCP{
+				Name:    "templated",
+				Command: "run",
+				Args:    []string{"--key", "${API_KEY}"},
+			},
+			env:      map[string]string{"API_KEY": "xyz"},
+			dryRun:   true,
+			contains: []string{"[dry-run]", "--key xyz"},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			var err error
+			out := captureStdout(t, func() {
+				err = AddClaude(tt.mcp, tt.env, tt.dryRun)
+			})
+			if err != nil {
+				t.Fatalf("AddClaude returned error: %v", err)
+			}
+			for _, want := range tt.contains {
+				if !strings.Contains(out, want) {
+					t.Errorf("stdout missing %q\ngot: %s", want, out)
+				}
+			}
+		})
+	}
+}
+
+func TestInstallOpencode(t *testing.T) {
+	const mcpName = "my-server"
+
+	// The entry InstallOpencode writes for a stdio MCP named my-server / cmd node.
+	// Built via ocEntry so the marshaled key order matches what InstallOpencode
+	// produces — that byte-for-byte match is what triggers the "skip" branch.
+	wantEntry := func() ocEntry {
+		return ocEntry{Type: "local", Command: []string{"node", "server.js"}}
+	}
+
+	tests := map[string]struct {
+		seed       func(path string) // optional pre-existing config
+		mcps       []MCP             // override; nil uses the default stdio my-server
+		env        map[string]string // override; nil uses empty env
+		dryRun     bool
+		reinstall  bool
+		wantNoFile bool
+		assert     func(t *testing.T, config map[string]interface{})
+	}{
+		"fresh write creates config with mcp entry": {
+			assert: func(t *testing.T, config map[string]interface{}) {
+				mcpMap, _ := config["mcp"].(map[string]interface{})
+				entry, ok := mcpMap[mcpName].(map[string]interface{})
+				if !ok {
+					t.Fatalf("mcp.%s missing: %v", mcpName, config)
+				}
+				if entry["type"] != "local" {
+					t.Errorf("type = %v, want local", entry["type"])
+				}
+				cmd, _ := entry["command"].([]interface{})
+				if len(cmd) != 2 || cmd[0] != "node" || cmd[1] != "server.js" {
+					t.Errorf("command = %v, want [node server.js]", cmd)
+				}
+			},
+		},
+		"merge preserves existing keys, adds new": {
+			seed: func(path string) {
+				seed := map[string]interface{}{
+					"topLevel": "keep-me",
+					"mcp": map[string]interface{}{
+						"other": map[string]interface{}{"type": "local", "command": []interface{}{"x"}},
+					},
+				}
+				data, _ := json.MarshalIndent(seed, "", "  ")
+				_ = os.WriteFile(path, data, 0o644)
+			},
+			assert: func(t *testing.T, config map[string]interface{}) {
+				if config["topLevel"] != "keep-me" {
+					t.Errorf("top-level key lost: %v", config["topLevel"])
+				}
+				mcpMap, _ := config["mcp"].(map[string]interface{})
+				if _, ok := mcpMap["other"]; !ok {
+					t.Errorf("existing mcp.other lost")
+				}
+				if _, ok := mcpMap[mcpName]; !ok {
+					t.Errorf("new mcp.%s not added", mcpName)
+				}
+			},
+		},
+		"merge identical entry skips, no rewrite": {
+			seed: func(path string) {
+				seed := map[string]interface{}{
+					"mcp": map[string]interface{}{
+						mcpName: wantEntry(),
+					},
+				}
+				data, _ := json.MarshalIndent(seed, "", "  ")
+				_ = os.WriteFile(path, data, 0o644)
+			},
+			assert: func(t *testing.T, config map[string]interface{}) {
+				mcpMap, _ := config["mcp"].(map[string]interface{})
+				if len(mcpMap) != 1 {
+					t.Errorf("mcp map size = %d, want 1", len(mcpMap))
+				}
+			},
+		},
+		"dry-run does not write": {
+			dryRun:     true,
+			wantNoFile: true,
+		},
+		"http transport writes remote entry with resolved headers": {
+			mcps: []MCP{{
+				Name:      "remote-server",
+				Transport: "http",
+				URL:       "https://example.com/mcp",
+				Headers:   map[string]string{"Authorization": "Bearer ${TOKEN}"},
+			}},
+			env: map[string]string{"TOKEN": "secret123"},
+			assert: func(t *testing.T, config map[string]interface{}) {
+				mcpMap, _ := config["mcp"].(map[string]interface{})
+				entry, ok := mcpMap["remote-server"].(map[string]interface{})
+				if !ok {
+					t.Fatalf("mcp.remote-server missing: %v", config)
+				}
+				if entry["type"] != "remote" {
+					t.Errorf("type = %v, want remote", entry["type"])
+				}
+				if entry["url"] != "https://example.com/mcp" {
+					t.Errorf("url = %v", entry["url"])
+				}
+				headers, _ := entry["headers"].(map[string]interface{})
+				if headers["Authorization"] != "Bearer secret123" {
+					t.Errorf("header not resolved: %v", headers["Authorization"])
+				}
+			},
+		},
+		"reinstall removes existing entry then re-adds": {
+			seed: func(path string) {
+				// Seed an OLD version of my-server so reinstall must remove+re-add.
+				seed := map[string]interface{}{
+					"mcp": map[string]interface{}{
+						mcpName: ocEntry{Type: "local", Command: []string{"old-cmd"}},
+					},
+				}
+				data, _ := json.MarshalIndent(seed, "", "  ")
+				_ = os.WriteFile(path, data, 0o644)
+			},
+			reinstall: true,
+			assert: func(t *testing.T, config map[string]interface{}) {
+				mcpMap, _ := config["mcp"].(map[string]interface{})
+				entry, ok := mcpMap[mcpName].(map[string]interface{})
+				if !ok {
+					t.Fatalf("mcp.%s missing after reinstall", mcpName)
+				}
+				cmd, _ := entry["command"].([]interface{})
+				if len(cmd) != 2 || cmd[0] != "node" {
+					t.Errorf("entry not re-added with new command: %v", cmd)
+				}
+			},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			configPath := filepath.Join(t.TempDir(), "opencode.json")
+
+			var beforeBytes []byte
+			if tt.seed != nil {
+				tt.seed(configPath)
+				beforeBytes, _ = os.ReadFile(configPath)
+			}
+
+			mcps := tt.mcps
+			if mcps == nil {
+				mcps = []MCP{{Name: mcpName, Command: "node", Args: []string{"server.js"}}}
+			}
+			env := tt.env
+			if env == nil {
+				env = map[string]string{}
+			}
+
+			var err error
+			_ = captureStdout(t, func() {
+				err = InstallOpencode(mcps, env, configPath, tt.dryRun, tt.reinstall)
+			})
+			if err != nil {
+				t.Fatalf("InstallOpencode returned error: %v", err)
+			}
+
+			if tt.wantNoFile {
+				if _, statErr := os.Stat(configPath); !os.IsNotExist(statErr) {
+					t.Fatalf("expected no file written, stat err = %v", statErr)
+				}
+				return
+			}
+
+			data, readErr := os.ReadFile(configPath)
+			if readErr != nil {
+				t.Fatalf("config not written: %v", readErr)
+			}
+
+			// "identical entry skips" should leave the file byte-for-byte unchanged.
+			if name == "merge identical entry skips, no rewrite" && beforeBytes != nil {
+				if string(data) != string(beforeBytes) {
+					t.Errorf("file was rewritten despite identical entry")
+				}
+			}
+
+			var config map[string]interface{}
+			if err := json.Unmarshal(data, &config); err != nil {
+				t.Fatalf("config not valid JSON: %v", err)
+			}
+			if tt.assert != nil {
+				tt.assert(t, config)
+			}
+		})
+	}
+}

--- a/cli/internal/ui/prompts.go
+++ b/cli/internal/ui/prompts.go
@@ -83,27 +83,9 @@ func MultiSelect(label string, items []string) ([]string, error) {
 	}
 
 	for {
-		count := 0
-		for _, s := range selected {
-			if s {
-				count++
-			}
-		}
-
-		display := make([]string, len(items)+2)
-		display[0] = fmt.Sprintf("✔  Done  (%d / %d selected)", count, len(items))
-		display[1] = "◎  Toggle all"
-		for i, item := range items {
-			if selected[i] {
-				display[i+2] = "✓  " + item
-			} else {
-				display[i+2] = "○  " + item
-			}
-		}
-
 		p := promptui.Select{
 			Label: label,
-			Items: display,
+			Items: buildMultiSelectDisplay(items, selected),
 			Size:  14,
 		}
 		idx, _, err := p.Run()
@@ -111,24 +93,70 @@ func MultiSelect(label string, items []string) ([]string, error) {
 			return nil, err
 		}
 
-		switch idx {
-		case 0: // Done
-			var result []string
-			for i, s := range selected {
-				if s {
-					result = append(result, items[i])
-				}
-			}
-			return result, nil
-		case 1: // Toggle all
-			allSelected := count == len(items)
-			for i := range selected {
-				selected[i] = !allSelected
-			}
-		default: // Toggle individual item
-			selected[idx-2] = !selected[idx-2]
+		if applyMultiSelectChoice(selected, idx) {
+			return collectSelected(items, selected), nil
 		}
 	}
+}
+
+// buildMultiSelectDisplay renders the checklist menu rows for the current
+// selection: row 0 is the "Done" line with the live count, row 1 is "Toggle
+// all", and the remaining rows mirror items with a ✓/○ marker per selected flag.
+func buildMultiSelectDisplay(items []string, selected []bool) []string {
+	count := 0
+	for _, s := range selected {
+		if s {
+			count++
+		}
+	}
+
+	display := make([]string, len(items)+2)
+	display[0] = fmt.Sprintf("✔  Done  (%d / %d selected)", count, len(items))
+	display[1] = "◎  Toggle all"
+	for i, item := range items {
+		if selected[i] {
+			display[i+2] = "✓  " + item
+		} else {
+			display[i+2] = "○  " + item
+		}
+	}
+	return display
+}
+
+// applyMultiSelectChoice mutates selected in response to a menu choice and
+// reports whether the user is done. idx 0 = Done, idx 1 = toggle-all
+// (deselect everything if all are currently selected, otherwise select all),
+// idx >= 2 toggles the item at idx-2.
+func applyMultiSelectChoice(selected []bool, idx int) (done bool) {
+	switch idx {
+	case 0: // Done
+		return true
+	case 1: // Toggle all
+		count := 0
+		for _, s := range selected {
+			if s {
+				count++
+			}
+		}
+		allSelected := count == len(selected)
+		for i := range selected {
+			selected[i] = !allSelected
+		}
+	default: // Toggle individual item
+		selected[idx-2] = !selected[idx-2]
+	}
+	return false
+}
+
+// collectSelected returns the items whose selected flag is set, preserving order.
+func collectSelected(items []string, selected []bool) []string {
+	var result []string
+	for i, s := range selected {
+		if s {
+			result = append(result, items[i])
+		}
+	}
+	return result
 }
 
 // ── Confirm ───────────────────────────────────────────────────────────────────

--- a/cli/internal/ui/ui_test.go
+++ b/cli/internal/ui/ui_test.go
@@ -140,6 +140,7 @@ func captureOutput(t *testing.T, fn func()) (string, string) {
 		t.Fatalf("os.Pipe: %v", err)
 	}
 	os.Stdout, os.Stderr = wOut, wErr
+	defer func() { os.Stdout, os.Stderr = origOut, origErr }()
 
 	outCh := drain(rOut)
 	errCh := drain(rErr)
@@ -148,7 +149,6 @@ func captureOutput(t *testing.T, fn func()) (string, string) {
 
 	_ = wOut.Close()
 	_ = wErr.Close()
-	os.Stdout, os.Stderr = origOut, origErr
 	return <-outCh, <-errCh
 }
 

--- a/cli/internal/ui/ui_test.go
+++ b/cli/internal/ui/ui_test.go
@@ -1,0 +1,212 @@
+package ui
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestMultiSelectLogic(t *testing.T) {
+	items := []string{"alpha", "beta", "gamma"}
+
+	allTrue := func() []bool { return []bool{true, true, true} }
+
+	tests := map[string]struct {
+		selected []bool
+		choice   int  // menu index passed to applyMultiSelectChoice
+		applyOne bool // whether to call applyMultiSelectChoice at all
+		wantDone bool // expected done flag (only when applyOne)
+		want     []string
+	}{
+		"initial state all selected": {
+			selected: allTrue(),
+			applyOne: false,
+			want:     []string{"alpha", "beta", "gamma"},
+		},
+		"single toggle deselects correct item": {
+			// idx 3 -> selected[1] (beta) toggled off; alpha & gamma remain.
+			selected: allTrue(),
+			choice:   3,
+			applyOne: true,
+			wantDone: false,
+			want:     []string{"alpha", "gamma"},
+		},
+		"toggle-all off when all selected": {
+			selected: allTrue(),
+			choice:   1,
+			applyOne: true,
+			wantDone: false,
+			want:     nil,
+		},
+		"toggle-all on when some deselected": {
+			selected: []bool{true, false, true},
+			choice:   1,
+			applyOne: true,
+			wantDone: false,
+			want:     []string{"alpha", "beta", "gamma"},
+		},
+		"done returns current set": {
+			selected: []bool{true, false, true},
+			choice:   0,
+			applyOne: true,
+			wantDone: true,
+			want:     []string{"alpha", "gamma"},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			if tt.applyOne {
+				done := applyMultiSelectChoice(tt.selected, tt.choice)
+				if done != tt.wantDone {
+					t.Errorf("done = %v, want %v", done, tt.wantDone)
+				}
+			}
+			got := collectSelected(items, tt.selected)
+			if !equalStrings(got, tt.want) {
+				t.Errorf("collectSelected = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildMultiSelectDisplay(t *testing.T) {
+	items := []string{"alpha", "beta", "gamma"}
+
+	tests := map[string]struct {
+		selected []bool
+		wantHead string   // expected row 0 (Done line)
+		wantRows []string // expected item rows (index 2..)
+	}{
+		"all selected shows full count and ticks": {
+			selected: []bool{true, true, true},
+			wantHead: "✔  Done  (3 / 3 selected)",
+			wantRows: []string{"✓  alpha", "✓  beta", "✓  gamma"},
+		},
+		"some deselected shows partial count and circles": {
+			selected: []bool{true, false, true},
+			wantHead: "✔  Done  (2 / 3 selected)",
+			wantRows: []string{"✓  alpha", "○  beta", "✓  gamma"},
+		},
+		"none selected shows zero count": {
+			selected: []bool{false, false, false},
+			wantHead: "✔  Done  (0 / 3 selected)",
+			wantRows: []string{"○  alpha", "○  beta", "○  gamma"},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := buildMultiSelectDisplay(items, tt.selected)
+			if len(got) != len(items)+2 {
+				t.Fatalf("len = %d, want %d", len(got), len(items)+2)
+			}
+			if got[0] != tt.wantHead {
+				t.Errorf("head = %q, want %q", got[0], tt.wantHead)
+			}
+			if got[1] != "◎  Toggle all" {
+				t.Errorf("row 1 = %q, want toggle-all", got[1])
+			}
+			if !equalStrings(got[2:], tt.wantRows) {
+				t.Errorf("item rows = %v, want %v", got[2:], tt.wantRows)
+			}
+		})
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// captureOutput swaps os.Stdout and os.Stderr for pipes, runs fn, and returns
+// (stdout, stderr).
+func captureOutput(t *testing.T, fn func()) (string, string) {
+	t.Helper()
+	origOut, origErr := os.Stdout, os.Stderr
+	rOut, wOut, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	rErr, wErr, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stdout, os.Stderr = wOut, wErr
+
+	outCh := drain(rOut)
+	errCh := drain(rErr)
+
+	fn()
+
+	_ = wOut.Close()
+	_ = wErr.Close()
+	os.Stdout, os.Stderr = origOut, origErr
+	return <-outCh, <-errCh
+}
+
+func drain(r *os.File) <-chan string {
+	ch := make(chan string)
+	go func() {
+		var sb strings.Builder
+		buf := make([]byte, 4096)
+		for {
+			n, err := r.Read(buf)
+			if n > 0 {
+				sb.Write(buf[:n])
+			}
+			if err != nil {
+				break
+			}
+		}
+		ch <- sb.String()
+	}()
+	return ch
+}
+
+func TestOutputFormatters(t *testing.T) {
+	tests := map[string]struct {
+		fn       func()
+		onStderr bool
+		contains []string
+	}{
+		"Info":    {fn: func() { Info("hello-info") }, contains: []string{"hello-info", "[devexp]"}},
+		"Success": {fn: func() { Success("hello-success") }, contains: []string{"hello-success", "[devexp]"}},
+		"Warn":    {fn: func() { Warn("hello-warn") }, contains: []string{"hello-warn", "[devexp]"}},
+		"Error":   {fn: func() { Error("hello-error") }, onStderr: true, contains: []string{"hello-error", "[devexp] ERROR:"}},
+		"Added":   {fn: func() { Added("item-add") }, contains: []string{"item-add", "+"}},
+		"Removed": {fn: func() { Removed("item-rm") }, contains: []string{"item-rm", "-"}},
+		"Updated": {fn: func() { Updated("item-up") }, contains: []string{"item-up", "~", "updated"}},
+		"Skipped": {fn: func() { Skipped("item-skip", "because") }, contains: []string{"item-skip", "[skip]", "because"}},
+		"DryRun":  {fn: func() { DryRun("would-do-thing") }, contains: []string{"would-do-thing", "[dry-run]"}},
+		"Required": {
+			fn:       func() { Required("svc", []string{"TOK"}) },
+			contains: []string{"svc", "[REQUIRED]", "TOK"},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			stdout, stderr := captureOutput(t, tt.fn)
+			out := stdout
+			if tt.onStderr {
+				if stdout != "" {
+					t.Errorf("expected nothing on stdout, got %q", stdout)
+				}
+				out = stderr
+			}
+			for _, want := range tt.contains {
+				if !strings.Contains(out, want) {
+					t.Errorf("output missing %q\ngot: %s", want, out)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #67.

Adds table-driven unit tests to three packages that ran during every `devexp` install but had **0% coverage** — the standing 🔴 from the 2026-06-15 `/improve` scorecard.

## Coverage (all per-package targets met)
| Package | Before | After | Target |
|---|---|---|---|
| `internal/assets` | 0% | **83.3%** | ≥80% |
| `internal/mcp` | 0% | **64.7%** | ≥60% |
| `internal/ui` | 0% | **61.5%** | ≥50% |

## What changed
- **New tests** — `assets_test.go`, `mcp_test.go`, `ui_test.go` (777 lines), following the repo's `map[string]struct{}` table-driven convention.
- **One non-test change** — `prompts.go`: extracted `MultiSelect`'s pure logic into `buildMultiSelectDisplay` / `applyMultiSelectChoice` / `collectSelected` so it's testable without a TTY. **Exported signature unchanged; behavior identical** (`count == len(selected)` ≡ original `len(items)`; `idx-2` arithmetic preserved). The 3 `cmd/install.go` call sites consume only the exported signature — unaffected, and `cmd/install.go` was not touched.

## Non-Goals (untested by design, per groom plan)
Interactive `promptui` flows (`SelectAction`/`Scope`/`Platform`/`Confirm`), real `claude`-CLI exec paths, and the `install.go` 500-line split (separate commitment).

## Verification
`go test ./... -race` green (all 10 pkgs) · `go vet` clean · `golangci-lint` 0 issues. Embedded assets staged via `./scripts/stage-assets.sh` before test (existing CI convention).

🤖 Delivered via `/deliver 67` (groom plan anchored @ 879a5c8).